### PR TITLE
Fix bug when no sequence number is present in VEVENT/VTODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,35 @@ the events into the debug buffer. If you send such a buffer in a bug
 report, please make very sure you have removed personal information
 from those events.
 
+#### Syncing TODO
+
+This section is experimental.  So please make sure you have backups before you
+use this.  Create issues if it doesn't work for you.  This was developed with a
+nextcloud 12 server, and it is not sure if it works somewhere else.  Please
+report if you have another setup, so we can fix that.
+
+To enable this, just use
+
+    (setq org-icalendar-include-todo 'all
+        org-caldav-sync-todo t)
+
+The first will include your todos to the exporter (org->cal) the second controls
+the use of downloaded vtodo events to import it to the `inbox`.
+
+It is also a good idea to set
+
+    (setq org-icalendar-categories '(local-tags))
+    
+so the tags on the nextcloud will not include the local category.  If you need
+that, leave a message.  On cal->org this would add it to the tags.
+
+See the variables `org-caldav-todo-priority` and
+`org-caldav-todo-percent-states` for some customization.
+
+I would recommend you to test this and report issues, because I also want to
+have a stable todo handling.
+
+
 #### Known Bugs
 
 * Recurring events created or changed on the calendar side cannot be

--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ synced and which not:
   `org-caldav-skip-conditions`. The syntax of the conditions is
   described in the doc-string of `org-agenda-skip-if`.
 
+* In case you just want to keep your remote calendar clean, set
+  `org-caldav-days-in-past` to the number of days you want to keep in
+  the past on the remote calendar.  This does not affect your org files,
+  it works just as a filter for entries older than N days.
+
 Note however that the normal `org-agenda-skip-function(-global)` will
 **not** have any effect on the icalendar exporter (this used to be the
 case, but changed with the new exporters).

--- a/README.md
+++ b/README.md
@@ -416,9 +416,12 @@ that, leave a message.  On cal->org this would add it to the tags.
 See the variables `org-caldav-todo-priority` and
 `org-caldav-todo-percent-states` for some customization.
 
+There is also `org-caldav-todo-deadline-schedule-warning-days` which can be set
+to `t` if you want to include a scheduled date.  Some apps like OpenTasks will
+move tasks out of the widget if there is a scheduled, until it actually starts.
+
 I would recommend you to test this and report issues, because I also want to
 have a stable todo handling.
-
 
 #### Known Bugs
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,11 @@ have a stable todo handling.
 * Pretty much everything besides SUMMARY, DESCRIPTION and time is
   ignored in iCalendar (like 'LOCATION', for instance).
 
+* When trying to sync todo entries org-mode's export to ical can create empty
+  entries.  org-caldav tries to sync this, which results in errors.
+  In this case you can set `org-icalender-sync-todo` to `t` instead of `'all`,
+  until it is fixed.
+
 #### How syncing happens (a.k.a. my little CalDAV rant)
 
 (This is probably not interesting, so you can just stop reading.)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ changes. See the variable `org-caldav-backup-file` for details.
 A special case are sexp entries like
 
     %%(diary-anniversary  2 2 1969) Foo's birthday
-    
+
     * Regular meeting
       <%%(diary-float t 4 2)>
 
@@ -409,7 +409,7 @@ the use of downloaded vtodo events to import it to the `inbox`.
 It is also a good idea to set
 
     (setq org-icalendar-categories '(local-tags))
-    
+
 so the tags on the nextcloud will not include the local category.  If you need
 that, leave a message.  On cal->org this would add it to the tags.
 

--- a/org-caldav-testsuite.el
+++ b/org-caldav-testsuite.el
@@ -128,7 +128,7 @@ moose
 (defun org-caldav-test-calendar-empty-p ()
   "Check if calendar is empty."
   (let ((output (org-caldav-url-dav-get-properties
-     (org-caldav-events-url) "resourcetype")))
+                 (org-caldav-events-url) "resourcetype")))
     (unless (eq (plist-get (cdar output) 'DAV:status) 200)
       (error "Could not query CalDAV URL %s: %s." (org-caldav-events-url) (prin1-to-string output)))
     (= (length output) 1)))
@@ -146,7 +146,7 @@ moose
   "Put initial events to calendar."
   (message "PUT")
   (let ((org-caldav-calendar-preamble org-caldav-test-preamble)
-  events)
+        events)
     (with-temp-buffer
       (insert org-caldav-test-ics1)
       (should (org-caldav-put-event (current-buffer)))
@@ -155,7 +155,7 @@ moose
       (should (org-caldav-put-event (current-buffer))))
     (should
      (setq events
-     (org-caldav-get-event-etag-list)))
+           (org-caldav-get-event-etag-list)))
     (should (assoc "orgcaldavtest@cal1" events))
     (should (assoc "orgcaldavtest-cal2" events))))
 
@@ -163,13 +163,13 @@ moose
   (let ((tmpdir (make-temp-file "org-caldav-test-" t)))
     (message "Using tempdir %s" tmpdir)
     (setq org-caldav-save-directory (expand-file-name "org-caldav-savedir" tmpdir)
-    org-caldav-test-orgfile (expand-file-name "test.org" tmpdir)
-    org-caldav-test-second-orgfile (expand-file-name "test-second.org" tmpdir)
-    org-caldav-test-inbox (expand-file-name "inbox.org" tmpdir)
-    org-id-locations-file (expand-file-name "org-id-locations" tmpdir)
-    org-id-locations nil
-    org-id-files nil
-    org-caldav-test-current-tempdir tmpdir))
+          org-caldav-test-orgfile (expand-file-name "test.org" tmpdir)
+          org-caldav-test-second-orgfile (expand-file-name "test-second.org" tmpdir)
+          org-caldav-test-inbox (expand-file-name "inbox.org" tmpdir)
+          org-id-locations-file (expand-file-name "org-id-locations" tmpdir)
+          org-id-locations nil
+          org-id-files nil
+          org-caldav-test-current-tempdir tmpdir))
   (make-directory org-caldav-save-directory)
   (with-current-buffer (find-file-noselect org-caldav-test-inbox)
     (save-buffer)))
@@ -178,9 +178,9 @@ moose
   (dolist (name '("test.org" "test-second.org" "inbox.org" "org-id-locations"))
     (let ((buf (get-buffer name)))
       (when buf
-  (with-current-buffer buf
-    (set-buffer-modified-p nil)
-    (kill-buffer)))))
+        (with-current-buffer buf
+          (set-buffer-modified-p nil)
+          (kill-buffer)))))
   (setq org-id-locations nil)
   (when org-caldav-test-current-tempdir
     (delete-directory org-caldav-test-current-tempdir t)
@@ -210,16 +210,16 @@ moose
   (org-caldav-sync)
   ;; Check result.
   (should (member `(,org-caldav-calendar-id "orgcaldavtest@cal1" new-in-cal cal->org)
-      org-caldav-sync-result))
+                  org-caldav-sync-result))
   (should (member `(,org-caldav-calendar-id "orgcaldavtest-cal2" new-in-cal cal->org)
-      org-caldav-sync-result))
+                  org-caldav-sync-result))
   (should (member `(,org-caldav-calendar-id "orgcaldavtest@org1" new-in-org org->cal)
-      org-caldav-sync-result))
+                  org-caldav-sync-result))
   (should (member `(,org-caldav-calendar-id "orgcaldavtest-org2" new-in-org org->cal)
-      org-caldav-sync-result))
+                  org-caldav-sync-result))
   ;; State file should exist now.
   (should (file-exists-p
-     (org-caldav-sync-state-filename org-caldav-calendar-id)))
+           (org-caldav-sync-state-filename org-caldav-calendar-id)))
   (let ((calevents (org-caldav-get-event-etag-list)))
     (should (= (length calevents) (length org-caldav-test-allevents)))
     ;; Org events should be in cal.
@@ -256,8 +256,8 @@ moose
   (message "3rd SYNC")
   (org-caldav-sync)
   (should (equal `((,org-caldav-calendar-id "orgcaldavtest-cal2" changed-in-org org->cal)
-       (,org-caldav-calendar-id "orgcaldavtest-org2" changed-in-org org->cal))
-     org-caldav-sync-result))
+                   (,org-caldav-calendar-id "orgcaldavtest-org2" changed-in-org org->cal))
+                 org-caldav-sync-result))
 
   ;; Check if those events correctly end up in calendar.
   (with-current-buffer (org-caldav-get-event "orgcaldavtest-cal2")
@@ -293,13 +293,13 @@ moose
       (replace-match "20121213" nil nil nil 2))
     (save-excursion
       (when (re-search-forward "SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
-  (replace-match (number-to-string
-      (1+ (string-to-number (match-string 1))))
-           nil t nil 1)))
+        (replace-match (number-to-string
+                        (1+ (string-to-number (match-string 1))))
+                       nil t nil 1)))
     (message "PUTting first changed event")
     (should (org-caldav-save-resource
-       (concat (org-caldav-events-url) (url-hexify-string "orgcaldavtest@cal1.ics"))
-       (encode-coding-string (buffer-string) 'utf-8))))
+             (concat (org-caldav-events-url) (url-hexify-string "orgcaldavtest@cal1.ics"))
+             (encode-coding-string (buffer-string) 'utf-8))))
 
   (with-current-buffer (org-caldav-get-event "orgcaldavtest@org1")
     (goto-char (point-min))
@@ -308,36 +308,36 @@ moose
       (replace-match "SUMMARY:This is a changed test"))
     (save-excursion
       (if (re-search-forward "DTSTART\\(;.*\\)?:\\(20121223T190000Z\\)" nil t)
-    (replace-match "20121213T180000Z" nil nil nil 2)
-  (re-search-forward "DTSTART\\(;.*\\)?:\\(20121223T200000\\)")
-  (replace-match "20121213T190000" nil nil nil 2)))
+          (replace-match "20121213T180000Z" nil nil nil 2)
+        (re-search-forward "DTSTART\\(;.*\\)?:\\(20121223T200000\\)")
+        (replace-match "20121213T190000" nil nil nil 2)))
     (save-excursion
       (if (re-search-forward "DTEND\\(;.*\\)?:\\(20121223T200000Z\\)" nil t)
-    (replace-match "20121213T190000Z" nil nil nil 2)
-  (re-search-forward "DTEND\\(;.*\\)?:\\(20121223T210000\\)")
-  (replace-match "20121213T200000" nil nil nil 2)))
+          (replace-match "20121213T190000Z" nil nil nil 2)
+        (re-search-forward "DTEND\\(;.*\\)?:\\(20121223T210000\\)")
+        (replace-match "20121213T200000" nil nil nil 2)))
     (save-excursion
       (when (re-search-forward "SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
-  (replace-match (number-to-string
-      (1+ (string-to-number (match-string 1))))
-           nil t nil 1)))
+        (replace-match (number-to-string
+                        (1+ (string-to-number (match-string 1))))
+                       nil t nil 1)))
     (message "PUTting second changed event")
     (should (org-caldav-save-resource
-       (concat (org-caldav-events-url) "orgcaldavtest@org1.ics")
-       (encode-coding-string (buffer-string) 'utf-8))))
+             (concat (org-caldav-events-url) "orgcaldavtest@org1.ics")
+             (encode-coding-string (buffer-string) 'utf-8))))
 
   ;; Aaaand sync!
   (message "4th SYNC")
   (org-caldav-sync)
 
   (should (equal `((,org-caldav-calendar-id "orgcaldavtest@cal1" changed-in-cal cal->org)
-       (,org-caldav-calendar-id "orgcaldavtest@org1" changed-in-cal cal->org))
-     org-caldav-sync-result))
+                   (,org-caldav-calendar-id "orgcaldavtest@org1" changed-in-cal cal->org))
+                 org-caldav-sync-result))
 
   (with-current-buffer (find-file-noselect org-caldav-test-inbox)
     (goto-char (point-min))
     (should (re-search-forward
-       "* Changed test appointment Number 1
+             "* Changed test appointment Number 1
 \\s-*:PROPERTIES:
 \\s-*:ID:\\s-*orgcaldavtest@cal1
 \\s-*:END:
@@ -348,7 +348,7 @@ moose
   (with-current-buffer (find-file-noselect org-caldav-test-orgfile)
     (goto-char (point-min))
     (should (re-search-forward
-       "* This is a changed test
+             "* This is a changed test
 \\s-*:PROPERTIES:
 \\s-*:ID:\\s-*orgcaldavtest@org1
 \\s-*:END:
@@ -367,7 +367,7 @@ moose
     (should-not (assoc '"orgcaldavtest@org1" calevents)))
   (should
    (equal org-caldav-sync-result
-    `((,org-caldav-calendar-id "orgcaldavtest@org1" deleted-in-org removed-from-cal))))
+          `((,org-caldav-calendar-id "orgcaldavtest@org1" deleted-in-org removed-from-cal))))
   (should-not
    (assoc '"orgcaldavtest@org1" org-caldav-event-list))
 
@@ -381,7 +381,7 @@ moose
 
   (should
    (equal org-caldav-sync-result
-      `((,org-caldav-calendar-id "orgcaldavtest-org2" deleted-in-cal removed-from-org))))
+          `((,org-caldav-calendar-id "orgcaldavtest-org2" deleted-in-cal removed-from-org))))
   ;; There shouldn't be anything left in that buffer
   (with-current-buffer (find-file-noselect org-caldav-test-orgfile)
     (goto-char (point-min))
@@ -397,11 +397,11 @@ moose
   (with-current-buffer (get-buffer-create "headingtest")
     (erase-buffer)
     (insert "* This is a test without timestamp in headline\n"
-      "  <2009-08-08 Sat 10:00>\n whatever\n foo\n bar\n")
+            "  <2009-08-08 Sat 10:00>\n whatever\n foo\n bar\n")
     (insert "* This is a test SCHEDULED: <2009-08-08 Sat> \n"
-      "  whatever\n foo\n bar\n")
+            "  whatever\n foo\n bar\n")
     (insert "*  <2009-08-08 Sat 14:00>  This is another test\n"
-      "  whatever\n foo\n bar\n")
+            "  whatever\n foo\n bar\n")
     (org-mode)
     (goto-char (point-min))
     (save-excursion
@@ -431,11 +431,11 @@ moose
                                     (append entry (list uid level)))
                              (setq foo (buffer-string)))))
       (should (string-match "\\*\\s-+The summary\n\\s-*<2015-01-01 Thu 19:00-20:00>\n\\s-*The description\n"
-                       (write-entry nil nil)))
+                            (write-entry nil nil)))
       (should (string-match "\\*\\*\\s-+The summary\n\\s-*<2015-01-01 Thu 19:00-20:00>\n\\s-*The description\n"
-                       (write-entry nil 2)))
+                            (write-entry nil 2)))
       (should (string-match "\\*\\s-+The summary\n\\s-*:PROPERTIES:\n\\s-*:ID:\\s-*1\n\\s-*:END:\n\\s-*<2015-01-01 Thu 19:00-20:00>\n\\s-*The description\n"
-                       (write-entry "1" nil))))))
+                            (write-entry "1" nil))))))
 
 (ert-deftest org-caldav-04-multiple-calendars ()
   (org-caldav-test-setup-temp-files)
@@ -455,14 +455,14 @@ moose
 
   (let
       ((org-caldav-calendars
-  `((:calendar-id ,(car org-caldav-test-calendar-names)
-      :url ,org-caldav-url
-      :files (,org-caldav-test-orgfile)
-      :inbox ,org-caldav-test-orgfile)
-    (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
-      :url ,org-caldav-url
-      :files (,org-caldav-test-second-orgfile)
-      :inbox ,org-caldav-test-second-orgfile))))
+        `((:calendar-id ,(car org-caldav-test-calendar-names)
+                        :url ,org-caldav-url
+                        :files (,org-caldav-test-orgfile)
+                        :inbox ,org-caldav-test-orgfile)
+          (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
+                        :url ,org-caldav-url
+                        :files (,org-caldav-test-second-orgfile)
+                        :inbox ,org-caldav-test-second-orgfile))))
     (org-caldav-sync))
 
   ;; Check that each calendar has one event
@@ -495,16 +495,16 @@ moose
   (message "Starting sync")
   (let
       ((org-caldav-calendars
-  `((:calendar-id ,(car org-caldav-test-calendar-names)
-      :url ,org-caldav-url
-      :skip-conditions  (regexp ":sometag:")
-      :files (,org-caldav-test-orgfile)
-      :inbox ,org-caldav-test-orgfile)
-    (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
-      :url ,org-caldav-url
-      :skip-conditions (notregexp ":sometag:")
-      :files (,org-caldav-test-orgfile)
-      :inbox ,org-caldav-test-orgfile))))
+        `((:calendar-id ,(car org-caldav-test-calendar-names)
+                        :url ,org-caldav-url
+                        :skip-conditions  (regexp ":sometag:")
+                        :files (,org-caldav-test-orgfile)
+                        :inbox ,org-caldav-test-orgfile)
+          (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
+                        :url ,org-caldav-url
+                        :skip-conditions (notregexp ":sometag:")
+                        :files (,org-caldav-test-orgfile)
+                        :inbox ,org-caldav-test-orgfile))))
     (org-caldav-sync))
 
   ;; Check that each calendar has one event
@@ -546,9 +546,9 @@ moose
   (should (org-caldav-get-event "orgcaldavtest-cal2"))
   ;; Sync result
   (should (equal
-     '(("test1" "orgcaldavtest@cal1" new-in-cal cal->org)
-       ("test1" "orgcaldavtest-cal2" new-in-cal cal->org))
-     org-caldav-sync-result))
+           '(("test1" "orgcaldavtest@cal1" new-in-cal cal->org)
+             ("test1" "orgcaldavtest-cal2" new-in-cal cal->org))
+           org-caldav-sync-result))
   (org-caldav-test-cleanup))
 
 ;; Check that we are able to detect when an Org file was removed from
@@ -579,10 +579,10 @@ moose
   (setq org-caldav-test-seen-prompt nil)
   (let (octest-seen-prompt)
     (cl-letf (((symbol-function 'yes-or-no-p)
-         (lambda (prompt)
-     (setq octest-seen-prompt prompt) nil)))
+               (lambda (prompt)
+                 (setq octest-seen-prompt prompt) nil)))
       (message "2nd sync")
       (should-error (org-caldav-sync))
       (should (string-match "WARNING: Previously synced"
-          octest-seen-prompt))))
+                            octest-seen-prompt))))
   (org-caldav-test-cleanup))

--- a/org-caldav-testsuite.el
+++ b/org-caldav-testsuite.el
@@ -128,7 +128,7 @@ moose
 (defun org-caldav-test-calendar-empty-p ()
   "Check if calendar is empty."
   (let ((output (org-caldav-url-dav-get-properties
-		 (org-caldav-events-url) "resourcetype")))
+     (org-caldav-events-url) "resourcetype")))
     (unless (eq (plist-get (cdar output) 'DAV:status) 200)
       (error "Could not query CalDAV URL %s: %s." (org-caldav-events-url) (prin1-to-string output)))
     (= (length output) 1)))
@@ -146,7 +146,7 @@ moose
   "Put initial events to calendar."
   (message "PUT")
   (let ((org-caldav-calendar-preamble org-caldav-test-preamble)
-	events)
+  events)
     (with-temp-buffer
       (insert org-caldav-test-ics1)
       (should (org-caldav-put-event (current-buffer)))
@@ -155,7 +155,7 @@ moose
       (should (org-caldav-put-event (current-buffer))))
     (should
      (setq events
-	   (org-caldav-get-event-etag-list)))
+     (org-caldav-get-event-etag-list)))
     (should (assoc "orgcaldavtest@cal1" events))
     (should (assoc "orgcaldavtest-cal2" events))))
 
@@ -163,13 +163,13 @@ moose
   (let ((tmpdir (make-temp-file "org-caldav-test-" t)))
     (message "Using tempdir %s" tmpdir)
     (setq org-caldav-save-directory (expand-file-name "org-caldav-savedir" tmpdir)
-	  org-caldav-test-orgfile (expand-file-name "test.org" tmpdir)
-	  org-caldav-test-second-orgfile (expand-file-name "test-second.org" tmpdir)
-	  org-caldav-test-inbox (expand-file-name "inbox.org" tmpdir)
-	  org-id-locations-file (expand-file-name "org-id-locations" tmpdir)
-	  org-id-locations nil
-	  org-id-files nil
-	  org-caldav-test-current-tempdir tmpdir))
+    org-caldav-test-orgfile (expand-file-name "test.org" tmpdir)
+    org-caldav-test-second-orgfile (expand-file-name "test-second.org" tmpdir)
+    org-caldav-test-inbox (expand-file-name "inbox.org" tmpdir)
+    org-id-locations-file (expand-file-name "org-id-locations" tmpdir)
+    org-id-locations nil
+    org-id-files nil
+    org-caldav-test-current-tempdir tmpdir))
   (make-directory org-caldav-save-directory)
   (with-current-buffer (find-file-noselect org-caldav-test-inbox)
     (save-buffer)))
@@ -178,9 +178,9 @@ moose
   (dolist (name '("test.org" "test-second.org" "inbox.org" "org-id-locations"))
     (let ((buf (get-buffer name)))
       (when buf
-	(with-current-buffer buf
-	  (set-buffer-modified-p nil)
-	  (kill-buffer)))))
+  (with-current-buffer buf
+    (set-buffer-modified-p nil)
+    (kill-buffer)))))
   (setq org-id-locations nil)
   (when org-caldav-test-current-tempdir
     (delete-directory org-caldav-test-current-tempdir t)
@@ -210,16 +210,16 @@ moose
   (org-caldav-sync)
   ;; Check result.
   (should (member `(,org-caldav-calendar-id "orgcaldavtest@cal1" new-in-cal cal->org)
-		  org-caldav-sync-result))
+      org-caldav-sync-result))
   (should (member `(,org-caldav-calendar-id "orgcaldavtest-cal2" new-in-cal cal->org)
-		  org-caldav-sync-result))
+      org-caldav-sync-result))
   (should (member `(,org-caldav-calendar-id "orgcaldavtest@org1" new-in-org org->cal)
-		  org-caldav-sync-result))
+      org-caldav-sync-result))
   (should (member `(,org-caldav-calendar-id "orgcaldavtest-org2" new-in-org org->cal)
-		  org-caldav-sync-result))
+      org-caldav-sync-result))
   ;; State file should exist now.
   (should (file-exists-p
-	   (org-caldav-sync-state-filename org-caldav-calendar-id)))
+     (org-caldav-sync-state-filename org-caldav-calendar-id)))
   (let ((calevents (org-caldav-get-event-etag-list)))
     (should (= (length calevents) (length org-caldav-test-allevents)))
     ;; Org events should be in cal.
@@ -256,8 +256,8 @@ moose
   (message "3rd SYNC")
   (org-caldav-sync)
   (should (equal `((,org-caldav-calendar-id "orgcaldavtest-cal2" changed-in-org org->cal)
-		   (,org-caldav-calendar-id "orgcaldavtest-org2" changed-in-org org->cal))
-		 org-caldav-sync-result))
+       (,org-caldav-calendar-id "orgcaldavtest-org2" changed-in-org org->cal))
+     org-caldav-sync-result))
 
   ;; Check if those events correctly end up in calendar.
   (with-current-buffer (org-caldav-get-event "orgcaldavtest-cal2")
@@ -293,13 +293,13 @@ moose
       (replace-match "20121213" nil nil nil 2))
     (save-excursion
       (when (re-search-forward "SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
-	(replace-match (number-to-string
-			(1+ (string-to-number (match-string 1))))
-		       nil t nil 1)))
+  (replace-match (number-to-string
+      (1+ (string-to-number (match-string 1))))
+           nil t nil 1)))
     (message "PUTting first changed event")
     (should (org-caldav-save-resource
-	     (concat (org-caldav-events-url) (url-hexify-string "orgcaldavtest@cal1.ics"))
-	     (encode-coding-string (buffer-string) 'utf-8))))
+       (concat (org-caldav-events-url) (url-hexify-string "orgcaldavtest@cal1.ics"))
+       (encode-coding-string (buffer-string) 'utf-8))))
 
   (with-current-buffer (org-caldav-get-event "orgcaldavtest@org1")
     (goto-char (point-min))
@@ -308,36 +308,36 @@ moose
       (replace-match "SUMMARY:This is a changed test"))
     (save-excursion
       (if (re-search-forward "DTSTART\\(;.*\\)?:\\(20121223T190000Z\\)" nil t)
-	  (replace-match "20121213T180000Z" nil nil nil 2)
-	(re-search-forward "DTSTART\\(;.*\\)?:\\(20121223T200000\\)")
-	(replace-match "20121213T190000" nil nil nil 2)))
+    (replace-match "20121213T180000Z" nil nil nil 2)
+  (re-search-forward "DTSTART\\(;.*\\)?:\\(20121223T200000\\)")
+  (replace-match "20121213T190000" nil nil nil 2)))
     (save-excursion
       (if (re-search-forward "DTEND\\(;.*\\)?:\\(20121223T200000Z\\)" nil t)
-	  (replace-match "20121213T190000Z" nil nil nil 2)
-	(re-search-forward "DTEND\\(;.*\\)?:\\(20121223T210000\\)")
-	(replace-match "20121213T200000" nil nil nil 2)))
+    (replace-match "20121213T190000Z" nil nil nil 2)
+  (re-search-forward "DTEND\\(;.*\\)?:\\(20121223T210000\\)")
+  (replace-match "20121213T200000" nil nil nil 2)))
     (save-excursion
       (when (re-search-forward "SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
-	(replace-match (number-to-string
-			(1+ (string-to-number (match-string 1))))
-		       nil t nil 1)))
+  (replace-match (number-to-string
+      (1+ (string-to-number (match-string 1))))
+           nil t nil 1)))
     (message "PUTting second changed event")
     (should (org-caldav-save-resource
-	     (concat (org-caldav-events-url) "orgcaldavtest@org1.ics")
-	     (encode-coding-string (buffer-string) 'utf-8))))
+       (concat (org-caldav-events-url) "orgcaldavtest@org1.ics")
+       (encode-coding-string (buffer-string) 'utf-8))))
 
   ;; Aaaand sync!
   (message "4th SYNC")
   (org-caldav-sync)
 
   (should (equal `((,org-caldav-calendar-id "orgcaldavtest@cal1" changed-in-cal cal->org)
-		   (,org-caldav-calendar-id "orgcaldavtest@org1" changed-in-cal cal->org))
-		 org-caldav-sync-result))
+       (,org-caldav-calendar-id "orgcaldavtest@org1" changed-in-cal cal->org))
+     org-caldav-sync-result))
 
   (with-current-buffer (find-file-noselect org-caldav-test-inbox)
     (goto-char (point-min))
     (should (re-search-forward
-	     "* Changed test appointment Number 1
+       "* Changed test appointment Number 1
 \\s-*:PROPERTIES:
 \\s-*:ID:\\s-*orgcaldavtest@cal1
 \\s-*:END:
@@ -348,7 +348,7 @@ moose
   (with-current-buffer (find-file-noselect org-caldav-test-orgfile)
     (goto-char (point-min))
     (should (re-search-forward
-	     "* This is a changed test
+       "* This is a changed test
 \\s-*:PROPERTIES:
 \\s-*:ID:\\s-*orgcaldavtest@org1
 \\s-*:END:
@@ -367,7 +367,7 @@ moose
     (should-not (assoc '"orgcaldavtest@org1" calevents)))
   (should
    (equal org-caldav-sync-result
-	  `((,org-caldav-calendar-id "orgcaldavtest@org1" deleted-in-org removed-from-cal))))
+    `((,org-caldav-calendar-id "orgcaldavtest@org1" deleted-in-org removed-from-cal))))
   (should-not
    (assoc '"orgcaldavtest@org1" org-caldav-event-list))
 
@@ -381,7 +381,7 @@ moose
 
   (should
    (equal org-caldav-sync-result
-  	  `((,org-caldav-calendar-id "orgcaldavtest-org2" deleted-in-cal removed-from-org))))
+      `((,org-caldav-calendar-id "orgcaldavtest-org2" deleted-in-cal removed-from-org))))
   ;; There shouldn't be anything left in that buffer
   (with-current-buffer (find-file-noselect org-caldav-test-orgfile)
     (goto-char (point-min))
@@ -397,11 +397,11 @@ moose
   (with-current-buffer (get-buffer-create "headingtest")
     (erase-buffer)
     (insert "* This is a test without timestamp in headline\n"
-	    "  <2009-08-08 Sat 10:00>\n whatever\n foo\n bar\n")
+      "  <2009-08-08 Sat 10:00>\n whatever\n foo\n bar\n")
     (insert "* This is a test SCHEDULED: <2009-08-08 Sat> \n"
-	    "  whatever\n foo\n bar\n")
+      "  whatever\n foo\n bar\n")
     (insert "*  <2009-08-08 Sat 14:00>  This is another test\n"
-	    "  whatever\n foo\n bar\n")
+      "  whatever\n foo\n bar\n")
     (org-mode)
     (goto-char (point-min))
     (save-excursion
@@ -452,17 +452,17 @@ moose
     (org-caldav-test-set-up))
   (let ((org-caldav-calendar-id (nth 1 org-caldav-test-calendar-names)))
     (org-caldav-test-set-up))
-  
+
   (let
       ((org-caldav-calendars
-	`((:calendar-id ,(car org-caldav-test-calendar-names)
-			:url ,org-caldav-url
-			:files (,org-caldav-test-orgfile)
-			:inbox ,org-caldav-test-orgfile)
-	  (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
-			:url ,org-caldav-url
-			:files (,org-caldav-test-second-orgfile)
-			:inbox ,org-caldav-test-second-orgfile))))
+  `((:calendar-id ,(car org-caldav-test-calendar-names)
+      :url ,org-caldav-url
+      :files (,org-caldav-test-orgfile)
+      :inbox ,org-caldav-test-orgfile)
+    (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
+      :url ,org-caldav-url
+      :files (,org-caldav-test-second-orgfile)
+      :inbox ,org-caldav-test-second-orgfile))))
     (org-caldav-sync))
 
   ;; Check that each calendar has one event
@@ -495,16 +495,16 @@ moose
   (message "Starting sync")
   (let
       ((org-caldav-calendars
-	`((:calendar-id ,(car org-caldav-test-calendar-names)
-			:url ,org-caldav-url
-			:skip-conditions  (regexp ":sometag:")
-			:files (,org-caldav-test-orgfile)
-			:inbox ,org-caldav-test-orgfile)
-	  (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
-			:url ,org-caldav-url
-			:skip-conditions (notregexp ":sometag:")
-			:files (,org-caldav-test-orgfile)
-			:inbox ,org-caldav-test-orgfile))))
+  `((:calendar-id ,(car org-caldav-test-calendar-names)
+      :url ,org-caldav-url
+      :skip-conditions  (regexp ":sometag:")
+      :files (,org-caldav-test-orgfile)
+      :inbox ,org-caldav-test-orgfile)
+    (:calendar-id ,(nth 1 org-caldav-test-calendar-names)
+      :url ,org-caldav-url
+      :skip-conditions (notregexp ":sometag:")
+      :files (,org-caldav-test-orgfile)
+      :inbox ,org-caldav-test-orgfile))))
     (org-caldav-sync))
 
   ;; Check that each calendar has one event
@@ -546,9 +546,9 @@ moose
   (should (org-caldav-get-event "orgcaldavtest-cal2"))
   ;; Sync result
   (should (equal
-	   '(("test1" "orgcaldavtest@cal1" new-in-cal cal->org)
-	     ("test1" "orgcaldavtest-cal2" new-in-cal cal->org))
-	   org-caldav-sync-result))
+     '(("test1" "orgcaldavtest@cal1" new-in-cal cal->org)
+       ("test1" "orgcaldavtest-cal2" new-in-cal cal->org))
+     org-caldav-sync-result))
   (org-caldav-test-cleanup))
 
 ;; Check that we are able to detect when an Org file was removed from
@@ -579,11 +579,10 @@ moose
   (setq org-caldav-test-seen-prompt nil)
   (let (octest-seen-prompt)
     (cl-letf (((symbol-function 'yes-or-no-p)
-	       (lambda (prompt)
-		 (setq octest-seen-prompt prompt) nil)))
+         (lambda (prompt)
+     (setq octest-seen-prompt prompt) nil)))
       (message "2nd sync")
       (should-error (org-caldav-sync))
       (should (string-match "WARNING: Previously synced"
-			    octest-seen-prompt))))
+          octest-seen-prompt))))
   (org-caldav-test-cleanup))
-

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -463,9 +463,13 @@ OAuth2 if necessary."
                               "<DAV:" property "/></DAV:prop></DAV:propfind>\n"))
         (extra '(("Depth" . "1") ("Content-type" . "text/xml"))))
     (let ((resultbuf (org-caldav-url-retrieve-synchronously
-                      url "PROPFIND" request-data extra)))
-      (when (= 0 (buffer-size resultbuf))
-        (org-caldav-debug-print 1 (format "org-caldav-url-dav-get-properties: could not get data from url: %s" url)))
+                       url "PROPFIND" request-data extra))
+           (retr 1))
+      (while (and (= 0 (buffer-size resultbuf)) (< retr org-caldav-retry-attempts))
+        (org-caldav-debug-print 1 (format "org-caldav-url-dav-get-properties: could not get data from url: %s\n trying again..." url))
+        (setq resultbuf (org-caldav-url-retrieve-synchronously
+                          url "PROPFIND" request-data extra))
+        (setq retr (1+ retr)))
       (org-caldav-namespace-bug-workaround resultbuf)
       (url-dav-process-response resultbuf url))))
 

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -205,7 +205,7 @@ accordingly.
 TODO: Store the priority in a property and use this property for sync.
 ")
 
- (defvar org-caldav-todo-percent-states '((0 "TODO") (1 "STARTED") (100 "DONE"))
+(defvar org-caldav-todo-percent-states '((0 "TODO") (1 "STARTED") (100 "DONE"))
   "Ical vtodo entries have a percent-complete tag, which has numeric values 0-100.
 
 Here we map it with todo keywords.  The default values can be
@@ -222,6 +222,10 @@ for details.
 Some people work with the NEXT keyword, to have better filtering
 for entries, the ical way would be to set priorities for that.  I
 use the NEXT with a percent-state of 1, setting STARTED to 2.")
+
+(defvar org-caldav-todo-deadline-schedule-warning-days nil
+  "When set to `t' this will use `org-deadline-warning-days' to
+  schedule the todo entries.")
 
 (defvar org-caldav-debug-level 1
   "Level of debug output in `org-caldav-debug-buffer'.
@@ -452,6 +456,8 @@ OAuth2 if necessary."
         (extra '(("Depth" . "1") ("Content-type" . "text/xml"))))
     (let ((resultbuf (org-caldav-url-retrieve-synchronously
                       url "PROPFIND" request-data extra)))
+      (when (= 0 (buffer-size resultbuf))
+        (org-caldav-debug-print 1 (format "org-caldav-url-dav-get-properties: could not get data from url: %s" url)))
       (org-caldav-namespace-bug-workaround resultbuf)
       (url-dav-process-response resultbuf url))))
 
@@ -969,7 +975,8 @@ The ics must be in the current buffer."
       (when seq
         (setq seq (1+ seq))
         (goto-char (point-min))
-        (re-search-forward "^SEQUENCE:")
+        (unless (re-search-forward "^SEQUENCE:" nil t)
+          (org-caldav-debug-print 2 (format "UID %s: SEQUENCE not in Buffer %s" (car event) (buffer-name))))
         (delete-region (point-at-bol) (+ 1 (point-at-eol)))
         (beginning-of-line)
         (insert "SEQUENCE:" (number-to-string seq) "\n")
@@ -1283,8 +1290,8 @@ is on s-expression."
        (let ((pt (apply 'org-agenda-skip-entry-if org-caldav-skip-conditions))
               (ts (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
               (stamp (or (org-entry-get nil "TIMESTAMP" t) (org-entry-get nil "CLOSED" t))))
-	 (when (or pt (and stamp (> ts (org-time-stamp-to-now stamp))))
-	   (delete-region (point) (or pt (org-end-of-subtree t)))))))))
+         (when (or pt (and stamp (> ts (org-time-stamp-to-now stamp))))
+           (delete-region (point) (or pt (org-end-of-subtree t)))))))))
 
 (defun org-caldav-timestamp-has-time-p (timestamp)
   "Checks whether a timestamp has a time.
@@ -1330,34 +1337,34 @@ time, and we ask the user to fix that."
   "Generate ICS file from `org-caldav-files'.
 Returns buffer containing the ICS file."
   (let ((icalendar-file
-	 (if (featurep 'ox-icalendar)
-	     'org-icalendar-combined-agenda-file
-	   'org-combined-agenda-icalendar-file))
-	(orgfiles (let ((inbox-file (org-caldav-inbox-file org-caldav-inbox)))
-		    (if (member inbox-file org-caldav-files)
-			org-caldav-files
-		      (append org-caldav-files
-			      (list inbox-file)))))
-	(org-export-select-tags org-caldav-select-tags)
-	(org-icalendar-exclude-tags org-caldav-exclude-tags)
-	;; We absolutely need UIDs for synchronization.
-	(org-icalendar-store-UID t)
-	;; Does not work yet
-	(org-icalendar-include-bbdb-anniversaries nil)
-	(icalendar-uid-format "orgsexp-%h")
-	(org-export-before-parsing-hook
-	 (append org-export-before-parsing-hook
+         (if (featurep 'ox-icalendar)
+             'org-icalendar-combined-agenda-file
+           'org-combined-agenda-icalendar-file))
+        (orgfiles (let ((inbox-file (org-caldav-inbox-file org-caldav-inbox)))
+                    (if (member inbox-file org-caldav-files)
+                        org-caldav-files
+                      (append org-caldav-files
+                              (list inbox-file)))))
+        (org-export-select-tags org-caldav-select-tags)
+        (org-icalendar-exclude-tags org-caldav-exclude-tags)
+        ;; We absolutely need UIDs for synchronization.
+        (org-icalendar-store-UID t)
+        ;; Does not work yet
+        (org-icalendar-include-bbdb-anniversaries nil)
+        (icalendar-uid-format "orgsexp-%h")
+        (org-export-before-parsing-hook
+         (append org-export-before-parsing-hook
            (when (or org-caldav-skip-conditions
                    org-caldav-days-in-past) '(org-caldav-skip-function))))
-	(org-icalendar-date-time-format
-	 (cond
-	  ((and org-icalendar-timezone
-		(string= org-icalendar-timezone "UTC"))
-	   ":%Y%m%dT%H%M%SZ")
-	  (org-icalendar-timezone
-	   ";TZID=%Z:%Y%m%dT%H%M%S")
-	  (t
-	   ":%Y%m%dT%H%M%S"))))
+        (org-icalendar-date-time-format
+         (cond
+          ((and org-icalendar-timezone
+                (string= org-icalendar-timezone "UTC"))
+           ":%Y%m%dT%H%M%SZ")
+          (org-icalendar-timezone
+           ";TZID=%Z:%Y%m%dT%H%M%S")
+          (t
+           ":%Y%m%dT%H%M%S"))))
     ;; check scheduled and deadline for having both time or noone (vtodo)
     (org-caldav-prepare-scheduled-deadline-timestamps orgfiles)
 
@@ -1501,13 +1508,13 @@ If UID is nil, no UID: property is written.
 If LEVEL is nil, it defaults to 1.
 
 Returns MD5 from entry."
-  (let* ((nprio (string-to-number priority))
+  (let* ((nprio (string-to-number (or priority "0")))
           (r nil)
           (vprio (dolist (p org-caldav-todo-priority r)
                    (when (>= nprio (car p))
                      (setq r (car (cdr p))))))
           (prio (if vprio (concat "[#" vprio "] ") ""))
-          (npercent (string-to-number percent-complete))
+          (npercent (string-to-number (or percent-complete "0")))
           (todostate (dolist (to org-caldav-todo-percent-states tstate)
                        (when (>= npercent (car to))
                          (setq tstate (car (cdr to)))))))
@@ -1526,7 +1533,7 @@ Returns MD5 from entry."
 ;;  (forward-line -1)
   (when uid
     (org-set-property "ID" (url-unhex-string uid)))
- ;; (org-set-tags-to org-caldav-select-tags)
+  (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
          (org-entry-beginning-position)
          (org-entry-end-position))))
@@ -1584,23 +1591,23 @@ This will not update description (at the moment)."
       ;; heading
       (org-caldav-change-heading (nth 6 tododata))
       ;; priority
-      (let* ((nprio (string-to-number (nth 4 tododata)))
+      (let* ((nprio (string-to-number (or (nth 4 tododata) "0")))
               (r nil)
               (vprio (dolist (p org-caldav-todo-priority r)
-                   (when (>= nprio (car p))
-                     (setq r (car (cdr p)))))))
+                       (when (>= nprio (car p))
+                         (setq r (car (cdr p)))))))
         (when vprio
           (org-priority (string-to-char vprio))))
       ;; todo-state
       (let* ((npercent (string-to-number (nth 5 tododata)))
               (todostate (dolist (to org-caldav-todo-percent-states tstate)
-                       (when (>= npercent (car to))
-                         (setq tstate (car (cdr to)))))))
+                           (when (>= npercent (car to))
+                             (setq tstate (car (cdr to)))))))
         (org-todo todostate))
       ;; scheduled, deadline
       (when (nth 0 tododata)
-    (org--deadline-or-schedule nil 'scheduled
-      (org-caldav-convert-to-org-time (nth 0 tododata) (nth 1 tododata))))
+        (org--deadline-or-schedule nil 'scheduled
+          (org-caldav-convert-to-org-time (nth 0 tododata) (nth 1 tododata))))
       (when (nth 2 tododata)
         (org--deadline-or-schedule nil 'deadline (org-caldav-convert-to-org-time (nth 2 tododata) (nth 3 tododata))))
       (when (nth 8 tododata)
@@ -1613,6 +1620,22 @@ This will not update description (at the moment)."
               (if (eq timesync 'orgsexp)
                 'error:changed-orgsexp 'cal->org))
         org-caldav-sync-result))))
+
+;; unused at the moment
+(defun org-caldav-generate-scheduled-from-deadline ()
+  "Create a scheduled entry from deadline."
+  (save-excursion
+    (org-back-to-heading)
+    (let* ((sched (org-element-property :scheduled (org-at-point)))
+            (ts (org-element-property :deadline (org-element-at-point)))
+            (wu (org-element-property :warning-unit ts))
+            (wv (org-element-property :warning-value ts))
+            nt)
+      (unless sched
+        (when wv
+          (org-setq nt (time-subtract))
+          )))))
+
 
 (defun org-caldav-set-org-tags (tags)
   "Set tags to the headline, where tags is a coma-seperated
@@ -1756,35 +1779,35 @@ See also `org-caldav-save-directory'."
   "Return items from sync results with errors.
 If COMPLEMENT is non-nil, return all item without errors."
   (delq nil
-        (mapcar
-         (lambda (x)
-           (if (string-match "^error" (symbol-name (car (last x))))
-               (unless complement x)
-             (when complement x)))
-         org-caldav-sync-result)))
+    (mapcar
+      (lambda (x)
+        (if (string-match "^error" (symbol-name (car (last x))))
+          (unless complement x)
+          (when complement x)))
+      org-caldav-sync-result)))
 
 (defun org-caldav-sync-result-print-entries (entries)
   "Helper function to print ENTRIES."
   (if (null entries)
-      (insert "None.\n")
+    (insert "None.\n")
     (dolist (entry entries)
       (let ((deleted (or (eq (nth 2 entry) 'deleted-in-org)
-                         (eq (nth 2 entry) 'deleted-in-cal))))
+                       (eq (nth 2 entry) 'deleted-in-cal))))
         (insert "UID: ")
         (let ((start (point)))
           (insert (nth 1 entry))
           (unless deleted
             (put-text-property start (point)
-                               'face 'link)))
+              'face 'link)))
         (when (and (eq org-caldav-show-sync-results 'with-headings)
-                   (not deleted))
+                (not deleted))
           (insert "\n   Title: "
-                  (or (org-caldav-get-heading-from-uid (nth 1 entry))
-                      "(no title)")))
+            (or (org-caldav-get-heading-from-uid (nth 1 entry))
+              "(no title)")))
         (insert "\n   Status: "
-                (symbol-name (nth 2 entry))
-                "  Action: "
-                (symbol-name (nth 3 entry)))
+          (symbol-name (nth 2 entry))
+          "  Action: "
+          (symbol-name (nth 3 entry)))
         (when org-caldav-calendars
           (insert "\n   Calendar: " (car entry)))
         (insert "\n\n")))))
@@ -1793,23 +1816,23 @@ If COMPLEMENT is non-nil, return all item without errors."
   "Get org heading from entry with UID."
   (let ((marker (org-id-find uid t)))
     (if (null marker)
-        "(Could not find UID)"
+      "(Could not find UID)"
       (with-current-buffer (marker-buffer marker)
         (goto-char (marker-position marker))
         (org-narrow-to-subtree)
         (goto-char (point-min))
         (org-show-subtree)
         (prog1
-            (if (re-search-forward org-complex-heading-regexp nil t)
-                (match-string 4)
-              "(Could not find heading)")
+          (if (re-search-forward org-complex-heading-regexp nil t)
+            (match-string 4)
+            "(Could not find heading)")
           (widen))))))
 
 (defun org-caldav-goto-uid ()
   "Jump to UID unter point."
   (interactive)
   (when (equal (plist-get (text-properties-at (point)) 'face)
-               'link)
+          'link)
     (beginning-of-line)
     (looking-at "UID: \\(.+\\)$")
     (org-id-goto (match-string 1))))
@@ -1817,7 +1840,7 @@ If COMPLEMENT is non-nil, return all item without errors."
 (defun org-caldav-get-calendar-summary-from-uid (uid)
   "Get summary from UID from calendar."
   (let ((buf (org-caldav-get-event uid))
-        (heading ""))
+         (heading ""))
     (when buf
       (with-current-buffer buf
         (goto-char (point-min))
@@ -1838,87 +1861,87 @@ which can be fed into `org-caldav-insert-org-entry'."
     (insert decoded))
   (goto-char (point-min))
   (let* ((calendar-date-style 'european)
-         (ical-list (icalendar--read-element nil nil))
-         (e (car (icalendar--all-events ical-list)))
-         (zone-map (icalendar--convert-all-timezones ical-list))
-         (dtstart (icalendar--get-event-property e 'DTSTART))
-         (dtstart-zone (icalendar--find-time-zone
+          (ical-list (icalendar--read-element nil nil))
+          (e (car (icalendar--all-events ical-list)))
+          (zone-map (icalendar--convert-all-timezones ical-list))
+          (dtstart (icalendar--get-event-property e 'DTSTART))
+          (dtstart-zone (icalendar--find-time-zone
+                          (icalendar--get-event-property-attributes
+                            e 'DTSTART)
+                          zone-map))
+          (dtstart-dec (icalendar--decode-isodatetime dtstart nil
+                         dtstart-zone))
+          (start-d (icalendar--datetime-to-diary-date
+                     dtstart-dec))
+          (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
+          (dtend (icalendar--get-event-property e 'DTEND))
+          (dtend-zone (icalendar--find-time-zone
                         (icalendar--get-event-property-attributes
-                         e 'DTSTART)
+                          e 'DTEND)
                         zone-map))
-         (dtstart-dec (icalendar--decode-isodatetime dtstart nil
-                                                     dtstart-zone))
-         (start-d (icalendar--datetime-to-diary-date
-                   dtstart-dec))
-         (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
-         (dtend (icalendar--get-event-property e 'DTEND))
-         (dtend-zone (icalendar--find-time-zone
-                      (icalendar--get-event-property-attributes
-                       e 'DTEND)
-                      zone-map))
-         (dtend-dec (icalendar--decode-isodatetime dtend
-                                                   nil dtend-zone))
-         (dtend-1-dec (icalendar--decode-isodatetime dtend -1
-                                                     dtend-zone))
-         end-d
-         end-1-d
-         end-t
-         (summary (icalendar--convert-string-for-import
-                   (or (icalendar--get-event-property e 'SUMMARY)
+          (dtend-dec (icalendar--decode-isodatetime dtend
+                       nil dtend-zone))
+          (dtend-1-dec (icalendar--decode-isodatetime dtend -1
+                         dtend-zone))
+          end-d
+          end-1-d
+          end-t
+          (summary (icalendar--convert-string-for-import
+                     (or (icalendar--get-event-property e 'SUMMARY)
                        "No Title")))
-         (description (icalendar--convert-string-for-import
-                       (or (icalendar--get-event-property e 'DESCRIPTION)
+          (description (icalendar--convert-string-for-import
+                         (or (icalendar--get-event-property e 'DESCRIPTION)
                            "")))
-         (rrule (icalendar--get-event-property e 'RRULE))
-         (rdate (icalendar--get-event-property e 'RDATE))
-         (duration (icalendar--get-event-property e 'DURATION)))
+          (rrule (icalendar--get-event-property e 'RRULE))
+          (rdate (icalendar--get-event-property e 'RDATE))
+          (duration (icalendar--get-event-property e 'DURATION)))
     ;; check whether start-time is missing
-    (if	(and dtstart
-             (string=
-              (cadr (icalendar--get-event-property-attributes
-                     e 'DTSTART))
-              "DATE"))
-        (setq start-t nil))
+    (if (and dtstart
+          (string=
+            (cadr (icalendar--get-event-property-attributes
+                    e 'DTSTART))
+            "DATE"))
+      (setq start-t nil))
     (when duration
       (let ((dtend-dec-d (icalendar--add-decoded-times
-                          dtstart-dec
-                          (icalendar--decode-isoduration duration)))
-            (dtend-1-dec-d (icalendar--add-decoded-times
-                            dtstart-dec
-                            (icalendar--decode-isoduration duration
-                                                           t))))
+                           dtstart-dec
+                           (icalendar--decode-isoduration duration)))
+             (dtend-1-dec-d (icalendar--add-decoded-times
+                              dtstart-dec
+                              (icalendar--decode-isoduration duration
+                                t))))
         (if (and dtend-dec (not (eq dtend-dec dtend-dec-d)))
-            (message "Inconsistent endtime and duration for %s"
-                     summary))
+          (message "Inconsistent endtime and duration for %s"
+            summary))
         (setq dtend-dec dtend-dec-d)
         (setq dtend-1-dec dtend-1-dec-d)))
     (setq end-d (if dtend-dec
-                    (icalendar--datetime-to-diary-date dtend-dec)
+                  (icalendar--datetime-to-diary-date dtend-dec)
                   start-d))
     (setq end-1-d (if dtend-1-dec
-                      (icalendar--datetime-to-diary-date dtend-1-dec)
+                    (icalendar--datetime-to-diary-date dtend-1-dec)
                     start-d))
     (setq end-t (if (and
-                     dtend-dec
-                     (not (string=
-                           (cadr
-                            (icalendar--get-event-property-attributes
-                             e 'DTEND))
-                           "DATE")))
-                    (icalendar--datetime-to-colontime dtend-dec)
+                      dtend-dec
+                      (not (string=
+                             (cadr
+                               (icalendar--get-event-property-attributes
+                                 e 'DTEND))
+                             "DATE")))
+                  (icalendar--datetime-to-colontime dtend-dec)
                   start-t))
     ;; Return result
     (list start-d start-t
-          (if end-t end-d end-1-d)
-          end-t summary description)))
+      (if end-t end-d end-1-d)
+      end-t summary description)))
 
 (defun org-caldav--icalendar--all-todos (icalendar)
   "Return the list of all existing todos in the given ICALENDAR."
   (let ((result '()))
     (mapc (lambda (elt)
             (setq result (append (icalendar--get-children elt 'VTODO)
-                                 result)))
-          (nreverse icalendar))
+                           result)))
+      (nreverse icalendar))
     result))
 
 
@@ -1935,71 +1958,79 @@ which can be fed into `org-caldav-insert-org-todo'."
     (insert decoded))
   (goto-char (point-min))
   (let* ((calendar-date-style 'european)
-         (ical-list (icalendar--read-element nil nil))
-         (e (car (org-caldav--icalendar--all-todos ical-list)))
-         (zone-map (icalendar--convert-all-timezones ical-list))
-         (dtstart (icalendar--get-event-property e 'DTSTART))
-         (dtstart-zone (icalendar--find-time-zone
+          (ical-list (icalendar--read-element nil nil))
+          (e (car (org-caldav--icalendar--all-todos ical-list)))
+          (zone-map (icalendar--convert-all-timezones ical-list))
+          (dtstart (icalendar--get-event-property e 'DTSTART))
+          (dtstart-zone (icalendar--find-time-zone
+                          (icalendar--get-event-property-attributes
+                            e 'DTSTART)
+                          zone-map))
+          (dtstart-dec (icalendar--decode-isodatetime dtstart nil
+                         dtstart-zone))
+          (start-d (icalendar--datetime-to-diary-date
+                     dtstart-dec))
+          (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
+          (dtdue (icalendar--get-event-property e 'DUE))
+          (dtdue-zone (icalendar--find-time-zone
                         (icalendar--get-event-property-attributes
-                         e 'DTSTART)
+                          e 'DUE)
                         zone-map))
-         (dtstart-dec (icalendar--decode-isodatetime dtstart nil
-                                                     dtstart-zone))
-         (start-d (icalendar--datetime-to-diary-date
-                   dtstart-dec))
-         (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
-         (dtdue (icalendar--get-event-property e 'DUE))
-         (dtdue-zone (icalendar--find-time-zone
-                      (icalendar--get-event-property-attributes
-                       e 'DUE)
-                      zone-map))
-         (dtdue-dec (icalendar--decode-isodatetime dtdue
-                                                   nil dtdue-zone))
+          (dtdue-dec (icalendar--decode-isodatetime dtdue
+                       nil dtdue-zone))
           (due-d (icalendar--datetime-to-diary-date
-                  dtdue-dec))
-         (due-t (if dtdue-dec (icalendar--datetime-to-colontime dtdue-dec) nil))
-         (dtcompleted (icalendar--get-event-property e 'COMPLETED))
-         (dtcompleted-zone (icalendar--find-time-zone
-                      (icalendar--get-event-property-attributes
-                       e 'COMPLETED)
-                      zone-map))
-         (dtcompleted-dec (icalendar--decode-isodatetime dtcompleted
-                                                   nil dtcompleted-zone))
+                   dtdue-dec))
+          (due-t (if dtdue-dec (icalendar--datetime-to-colontime dtdue-dec) nil))
+          (dtcompleted (icalendar--get-event-property e 'COMPLETED))
+          (dtcompleted-zone (icalendar--find-time-zone
+                              (icalendar--get-event-property-attributes
+                                e 'COMPLETED)
+                              zone-map))
+          (dtcompleted-dec (icalendar--decode-isodatetime dtcompleted
+                             nil dtcompleted-zone))
           (completed-d (icalendar--datetime-to-diary-date
-                  dtcompleted-dec))
-         (completed-t (if dtcompleted-dec (icalendar--datetime-to-colontime dtcompleted-dec) nil))
-         (summary (icalendar--convert-string-for-import
-                   (or (icalendar--get-event-property e 'SUMMARY)
+                         dtcompleted-dec))
+          (completed-t (if dtcompleted-dec (icalendar--datetime-to-colontime dtcompleted-dec) nil))
+          (summary (icalendar--convert-string-for-import
+                     (or (icalendar--get-event-property e 'SUMMARY)
                        "No Title")))
-         (description (icalendar--convert-string-for-import
-                       (or (icalendar--get-event-property e 'DESCRIPTION)
-                         "")))
+          (description (icalendar--convert-string-for-import
+                         (or (icalendar--get-event-property e 'DESCRIPTION)
+                           "")))
           (categories (icalendar--convert-string-for-import
                         (or (icalendar--get-event-property e 'CATEGORIES)
                           "")))
           (priority (icalendar--get-event-property e 'PRIORITY))
-          (percent-complete (icalendar--get-event-property e 'PERCENT-COMPLETE)))
+          (percent-complete (icalendar--get-event-property e 'PERCENT-COMPLETE))
+          (stat (icalendar--get-event-property e 'STATUS)))
     ;; check wether start-time is missing
-    (if	(and dtstart
-             (string=
-              (cadr (icalendar--get-event-property-attributes
-                     e 'DTSTART))
-              "DATE"))
-        (setq start-t nil))
+    (if (and dtstart
+          (string=
+            (cadr (icalendar--get-event-property-attributes
+                    e 'DTSTART))
+            "DATE"))
+      (setq start-t nil))
     ;; same for due-time
-    (if	(and dtdue
-             (string=
-              (cadr (icalendar--get-event-property-attributes
-                     e 'DUE))
-              "DATE"))
-        (setq due-t nil))
+    (if (and dtdue
+          (string=
+            (cadr (icalendar--get-event-property-attributes
+                    e 'DUE))
+            "DATE"))
+      (setq due-t nil))
     ;; and completed
-    (if	(and dtcompleted
-             (string=
-              (cadr (icalendar--get-event-property-attributes
-                     e 'COMPLETED))
-              "DATE"))
-        (setq completed-t nil))
+    (if (and dtcompleted
+          (string=
+            (cadr (icalendar--get-event-property-attributes
+                    e 'COMPLETED))
+            "DATE"))
+      (setq completed-t nil))
+    (unless percent-complete
+      (setq percent-complete
+        (cond
+          ((string= stat "NEEDS-ACTION") "0")
+          ((string= stat "IN-PROCESS") "50")
+          ((string= stat "COMPLETED") "100")
+          (t "0"))))
     (list start-d start-t
       due-d due-t
       priority percent-complete

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1646,17 +1646,21 @@ This will not update description (at the moment)."
                 (ts (org-element-property :deadline (org-element-at-point)))
                 (raw (org-element-property :raw-value ts))
                 (wu (org-element-property :warning-unit ts))
-                (wv (org-element-property :warning-value ts)))
-          (when (and ts (not sched))
-            (org--deadline-or-schedule nil 'scheduled raw)
-            (search-forward "SCHEDULED: ")
-            (forward-char)
-            (if wv
-              (progn
-                (cond ((eq wu 'week) (setq wu 'day wv (* wv 7)))
-                  ((eq wu 'hour) (setq wu 'minute wv (* wv 60))))
-                (org-timestamp-change (* wv -1) wu))
-              (org-timestamp-change (* org-deadline-warning-days -1) 'day)))
+                (wv (org-element-property :warning-value ts))
+                (dip (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
+                (stamp (org-entry-get nil "DEADLINE")))
+          ;; skip if to old:
+          (unless (and dip stamp (> dip (org-time-stamp-to-now stamp)))
+            (when (and ts (not sched))
+              (org--deadline-or-schedule nil 'scheduled raw)
+              (search-forward "SCHEDULED: ")
+              (forward-char)
+              (if wv
+                (progn
+                  (cond ((eq wu 'week) (setq wu 'day wv (* wv 7)))
+                    ((eq wu 'hour) (setq wu 'minute wv (* wv 60))))
+                  (org-timestamp-change (* wv -1) wu))
+                (org-timestamp-change (* org-deadline-warning-days -1) 'day))))
           (org-back-to-heading)
           (org-caldav-debug-print 2 (format "scheduled: %s" (org-entry-get nil
                                                               "SCHEDULED" t))))))))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -164,12 +164,56 @@ include headings from Org entries.")
   "Number of times trying to retrieve/put events.")
 
 (defvar org-caldav-calendar-preamble
-  "BEGIN:VCALENDAR\nPRODID:\nVERSION:2.0\nCALSCALE:GREGORIAN\n"
+  "BEGIN:VCALENDAR\nPRODID:-//emacs//org-caldav//EN\nVERSION:2.0\nCALSCALE:GREGORIAN\n"
   "Preamble used for iCalendar events.
 You usually should not have to touch this, but it might be
 necessary to add timezone information here in case your CalDAV
 server does not do that for you, or if you want to use a
 different timezone in your Org files.")
+
+(defvar org-caldav-sync-todo nil
+  "Experimental feature of syncing vtodo events along with the
+vevent.  Please make sure to save all your data before helping us
+to thest this feature.  If you enable this, you should set
+`org-icalendar-include-todo' to `\'all', to have the best
+experience.")
+
+(defvar org-caldav-todo-priority '((0 nil) (1 "A") (5 "B") (9 "C"))
+  "This maps the ical priority, which has numerical value, to the
+org-mode priority values.
+
+If you have changed the default priority levels for org mode,
+please change this too.
+
+CAUTION: Nextcloud has priority 0 (not set) and 1-9 for high to
+low.  org-mode default has not set, but only A (high) to
+C (low).  The behaviour is following: Getting new entries between
+9 will synced localy as C, 5-8 as B and 1-4 as A.
+
+If you want to change this see
+`http://orgmode.org/manual/Priorities.html' and change this here
+accordingly.
+
+TODO: Store the priority in a property and use this property for sync.
+")
+
+ (defvar org-caldav-todo-percent-states '((0 "TODO") (1 "STARTED") (100 "DONE"))
+  "Ical vtodo entries have a percent-complete tag, which has numeric values 0-100.
+
+Here we map it with todo keywords.  The default values can be
+  explained as: 0 is TODO, 1-99 is STARTED and 100 is
+  DONE.  (Higher than rule, highest value wins.)
+
+NOTE: STARTED is not default in org-todo-keywords, so this rule
+may be omitted if you didn't set it.  See
+`http://orgmode.org/manual/Workflow-states.html#Workflow-states'
+and
+`http://orgmode.org/manual/Per_002dfile-keywords.html#Per_002dfile-keywords'
+for details.
+
+Some people work with the NEXT keyword, to have better filtering
+for entries, the ical way would be to set priorities for that.  I
+use the NEXT with a percent-state of 1, setting STARTED to 2.")
 
 (defvar org-caldav-debug-level 1
   "Level of debug output in `org-caldav-debug-buffer'.
@@ -190,9 +234,9 @@ always = Always resume")
 
 (defvar org-caldav-oauth2-providers
   '((google "https://accounts.google.com/o/oauth2/auth"
-	    "https://accounts.google.com/o/oauth2/token"
-	    "https://www.googleapis.com/auth/calendar"
-	    "https://apidata.googleusercontent.com/caldav/v2/%s/events"))
+           "https://accounts.google.com/o/oauth2/token"
+           "https://www.googleapis.com/auth/calendar"
+           "https://apidata.googleusercontent.com/caldav/v2/%s/events"))
   "List of providers that need OAuth2.  Each must be of the form
 
     IDENTIFIER AUTH-URL TOKEN-URL RESOURCE-URL CALENDAR-URL
@@ -246,8 +290,8 @@ and  action = {org->cal, cal->org, error:org->cal, error:cal->org}.")
 (defsubst org-caldav-add-event (uid md5 etag sequence status)
   "Add event with UID, MD5, ETAG and STATUS."
   (setq org-caldav-event-list
-	(append org-caldav-event-list
-		(list (list uid md5 etag sequence status)))))
+        (append org-caldav-event-list
+                (list (list uid md5 etag sequence status)))))
 
 (defsubst org-caldav-search-event (uid)
   "Return entry with UID from even list."
@@ -291,11 +335,11 @@ and  action = {org->cal, cal->org, error:org->cal, error:cal->org}.")
 (defun org-caldav-filter-events (status)
   "Return list of events with STATUS."
   (delq nil
-	(mapcar
-	 (lambda (event)
-	   (when (eq (car (last event)) status)
-	     event))
-	 org-caldav-event-list)))
+        (mapcar
+         (lambda (event)
+           (when (eq (car (last event)) status)
+             event))
+         org-caldav-event-list)))
 
 ;; Since not being able to access an URL via DAV is the most reported
 ;; error, let's be very verbose about checking for DAV availability.
@@ -303,25 +347,25 @@ and  action = {org->cal, cal->org, error:org->cal, error:cal->org}.")
   "Check if URL accepts DAV requests.
 Report an error with further details if that is not the case."
   (let* ((buffer (org-caldav-url-retrieve-synchronously url "OPTIONS"))
-	 (header nil)
-	 (options nil))
+         (header nil)
+         (options nil))
     (when (not buffer)
       (error "Retrieving URL %s failed." url))
     (with-current-buffer buffer
       (goto-char (point-min))
       (when (not (re-search-forward "^HTTP[^ ]* \\([0-9]+ .*\\)$"
-				    (point-at-eol) t))
-	(switch-to-buffer buffer)
-	(error "No valid HTTP response from URL %s." url))
+                                    (point-at-eol) t))
+        (switch-to-buffer buffer)
+        (error "No valid HTTP response from URL %s." url))
       (let ((response (match-string 1)))
-	(when (not (string-match "2[0-9][0-9].*" response))
-	  (switch-to-buffer buffer)
-	  (error "Error while checking for OPTIONS at URL %s: %s" url response)))
+        (when (not (string-match "2[0-9][0-9].*" response))
+          (switch-to-buffer buffer)
+          (error "Error while checking for OPTIONS at URL %s: %s" url response)))
       (mail-narrow-to-head)
       (let ((davheader (mail-fetch-field "dav")))
-	(when (not davheader)
-	  (switch-to-buffer buffer)
-	  (error "The URL %s does not accept DAV requests" url)))))
+        (when (not davheader)
+          (switch-to-buffer buffer)
+          (error "The URL %s does not accept DAV requests" url)))))
   t)
 
 (defun org-caldav-check-oauth2 (provider)
@@ -330,40 +374,40 @@ If that is the case, also check that everything is installed and
 configured correctly, and throw an user error otherwise."
   (when (null (assoc provider org-caldav-oauth2-providers))
     (user-error (concat "No OAuth2 provider found for %s in "
-			"`org-caldav-oauth2-providers'")
-		(symbol-name provider)))
+                        "`org-caldav-oauth2-providers'")
+                (symbol-name provider)))
   (when (not org-caldav-oauth2-available)
     (user-error (concat "Oauth2 library is missing "
-			"(install from GNU ELPA)")))
+                        "(install from GNU ELPA)")))
   (when (or (null org-caldav-oauth2-client-id)
-	    (null org-caldav-oauth2-client-secret))
+            (null org-caldav-oauth2-client-secret))
     (user-error (concat "You need to set oauth2 client ID and secret "
-			"for OAuth2 authentication"))))
+                        "for OAuth2 authentication"))))
 
 (defun org-caldav-retrieve-oauth2-token (provider calendar-id)
   "Do OAuth2 authentication for PROVIDER with CALENDAR-ID."
   (let ((cached-token
-	 (assoc
-	  (concat (symbol-name provider) "__" calendar-id)
-	  org-caldav-oauth2-tokens)))
+         (assoc
+          (concat (symbol-name provider) "__" calendar-id)
+          org-caldav-oauth2-tokens)))
     (if cached-token
-	(cdr cached-token)
+        (cdr cached-token)
       (let* ((ids (assoc provider org-caldav-oauth2-providers))
-	     (token (oauth2-auth-and-store (nth 1 ids) (nth 2 ids) (nth 3 ids)
-					   org-caldav-oauth2-client-id
-					   org-caldav-oauth2-client-secret)))
-	(when (null token)
-	  (user-error "OAuth2 authentication failed"))
-	(setq org-caldav-oauth2-tokens
-	      (append org-caldav-oauth2-tokens
-		      (list (cons (concat (symbol-name provider) "__" calendar-id)
-				  token))))
-	token))))
+             (token (oauth2-auth-and-store (nth 1 ids) (nth 2 ids) (nth 3 ids)
+                                           org-caldav-oauth2-client-id
+                                           org-caldav-oauth2-client-secret)))
+        (when (null token)
+          (user-error "OAuth2 authentication failed"))
+        (setq org-caldav-oauth2-tokens
+              (append org-caldav-oauth2-tokens
+                      (list (cons (concat (symbol-name provider) "__" calendar-id)
+                                  token))))
+        token))))
 
 (defun org-caldav-url-retrieve-synchronously (url &optional
-					      request-method
-					      request-data
-					      extra-headers)
+                                              request-method
+                                              request-data
+                                              extra-headers)
   "Retrieve URL with REQUEST-METHOD, REQUEST-DATA and EXTRA-HEADERS.
 This will switch to OAuth2 if necessary."
   (if (org-caldav-use-oauth2)
@@ -372,8 +416,8 @@ This will switch to OAuth2 if necessary."
        url request-method request-data
        extra-headers)
     (let ((url-request-method request-method)
-	  (url-request-data request-data)
-	  (url-request-extra-headers extra-headers))
+          (url-request-data request-data)
+          (url-request-extra-headers extra-headers))
       (url-retrieve-synchronously url))))
 
 (defun org-caldav-namespace-bug-workaround (buffer)
@@ -383,23 +427,23 @@ default namespace."
   (when (< emacs-major-version 26)
     (with-current-buffer buffer
       (save-excursion
-	(goto-char (point-min))
-	(when (re-search-forward "<[^>]* \\(xmlns=\"DAV:\"\\)" nil t)
-	  (replace-match "xmlns:DAV=\"DAV:\"" nil nil nil 1)
-	  (goto-char (match-beginning 0))
-	  (while (re-search-forward "</?" nil t)
-	    (insert "DAV:")))))))
+        (goto-char (point-min))
+        (when (re-search-forward "<[^>]* \\(xmlns=\"DAV:\"\\)" nil t)
+          (replace-match "xmlns:DAV=\"DAV:\"" nil nil nil 1)
+          (goto-char (match-beginning 0))
+          (while (re-search-forward "</?" nil t)
+            (insert "DAV:")))))))
 
 (defun org-caldav-url-dav-get-properties (url property)
   "Retrieve PROPERTY from URL.
 Output is the same as `url-dav-get-properties'.  This switches to
 OAuth2 if necessary."
   (let ((request-data (concat "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
-			      "<DAV:propfind xmlns:DAV='DAV:'>\n<DAV:prop>"
-			      "<DAV:" property "/></DAV:prop></DAV:propfind>\n"))
-	(extra '(("Depth" . "1") ("Content-type" . "text/xml"))))
+                              "<DAV:propfind xmlns:DAV='DAV:'>\n<DAV:prop>"
+                              "<DAV:" property "/></DAV:prop></DAV:propfind>\n"))
+        (extra '(("Depth" . "1") ("Content-type" . "text/xml"))))
     (let ((resultbuf (org-caldav-url-retrieve-synchronously
-		      url "PROPFIND" request-data extra)))
+                      url "PROPFIND" request-data extra)))
       (org-caldav-namespace-bug-workaround resultbuf)
       (url-dav-process-response resultbuf url))))
 
@@ -407,26 +451,26 @@ OAuth2 if necessary."
   "Check connection by doing a PROPFIND on CalDAV URL.
 Also sets `org-caldav-empty-calendar' if calendar is empty."
   (org-caldav-debug-print 1 (format "Check connection for %s."
-				    (org-caldav-events-url)))
+                                    (org-caldav-events-url)))
   (org-caldav-check-dav (org-caldav-events-url))
   (let* ((output (org-caldav-url-dav-get-properties
-		  (org-caldav-events-url) "resourcetype"))
-	 (status (plist-get (cdar output) 'DAV:status)))
+                  (org-caldav-events-url) "resourcetype"))
+         (status (plist-get (cdar output) 'DAV:status)))
     ;; We accept any 2xx status. Since some CalDAV servers return 404
     ;; for a newly created and not yet used calendar, we accept it as
     ;; well.
     (unless (or (= (/ status 100) 2)
-		(= status 404))
+                (= status 404))
       (org-caldav-debug-print 1 "Got error status from PROPFIND: " output)
       (error "Could not query CalDAV URL %s." (org-caldav-events-url)))
     (if (= status 404)
-	(progn
-	  (org-caldav-debug-print 1 "Got 404 status - assuming calendar is new and empty.")
-	  (setq org-caldav-empty-calendar t))
+        (progn
+          (org-caldav-debug-print 1 "Got 404 status - assuming calendar is new and empty.")
+          (setq org-caldav-empty-calendar t))
       (when (= (length output) 1)
-	;; This is an empty calendar; fetching etags might return 404.
-	(org-caldav-debug-print 1 "This is an empty calendar. Setting flag.")
-	(setq org-caldav-empty-calendar t)))
+        ;; This is an empty calendar; fetching etags might return 404.
+        (org-caldav-debug-print 1 "This is an empty calendar. Setting flag.")
+        (setq org-caldav-empty-calendar t)))
     t))
 
 ;; This defun is partly taken out of url-dav.el, written by Bill Perry.
@@ -435,14 +479,14 @@ Also sets `org-caldav-empty-calendar' if calendar is empty."
   (let (prop files)
     (while (setq prop (pop properties))
       (let ((url (car prop))
-	    (etag (plist-get (cdr prop) 'DAV:getetag)))
+            (etag (plist-get (cdr prop) 'DAV:getetag)))
       (if (string-match (concat ".*/\\(.+\\)\\" org-caldav-uuid-extension "/?$") url)
-	  (setq url (match-string 1 url))
-	(setq url nil))
+          (setq url (match-string 1 url))
+        (setq url nil))
       (when (string-match "\"\\(.*\\)\"" etag)
-	(setq etag (match-string 1 etag)))
+        (setq etag (match-string 1 etag)))
       (when (and url etag)
-	(push (cons (url-unhex-string url) etag) files))))
+        (push (cons (url-unhex-string url) etag) files))))
     files))
 
 (defun org-caldav-get-event-etag-list ()
@@ -451,27 +495,27 @@ Return list with elements (uid . etag)."
   (if org-caldav-empty-calendar
       nil
     (let ((output (org-caldav-url-dav-get-properties
-		   (org-caldav-events-url) "getetag")))
+                   (org-caldav-events-url) "getetag")))
       (cond
        ((> (length output) 1)
-	;; Everything looks OK - we got a list of "things".
-	;; Get all ics files and etags you can find in there.
-	(org-caldav-get-icsfiles-etags-from-properties output))
+        ;; Everything looks OK - we got a list of "things".
+        ;; Get all ics files and etags you can find in there.
+        (org-caldav-get-icsfiles-etags-from-properties output))
        ((or (null output)
-	    (zerop (length output)))
-	;; This is definitely an error.
-	(error "Error while getting eventlist from %s." (org-caldav-events-url)))
+            (zerop (length output)))
+        ;; This is definitely an error.
+        (error "Error while getting eventlist from %s." (org-caldav-events-url)))
        ((and (= (length output) 1)
-	     (stringp (car-safe (car output))))
-	(let ((status (plist-get (cdar output) 'DAV:status)))
-	  (if (eq status 200)
-	      ;; This is an empty directory
-	      'empty
-	    (if status
-		(error "Error while getting eventlist from %s. Got status code: %d."
-		       (org-caldav-events-url) status)
-	      (error "Error while getting eventlist from %s."
-		     (org-caldav-events-url))))))))))
+             (stringp (car-safe (car output))))
+        (let ((status (plist-get (cdar output) 'DAV:status)))
+          (if (eq status 200)
+              ;; This is an empty directory
+              'empty
+            (if status
+                (error "Error while getting eventlist from %s. Got status code: %d."
+                       (org-caldav-events-url) status)
+              (error "Error while getting eventlist from %s."
+                     (org-caldav-events-url))))))))))
 
 (defun org-caldav-get-event (uid &optional with-headers)
   "Get event with UID from calendar.
@@ -481,42 +525,54 @@ If WITH-HEADERS is non-nil, do not delete headers.
 If retrieve fails, do `org-caldav-retry-attempts' retries."
   (org-caldav-debug-print 1 (format "Getting event UID %s." uid))
   (let ((counter 0)
-	eventbuffer errormessage)
+        eventbuffer errormessage)
     (while (and (not eventbuffer)
-		(< counter org-caldav-retry-attempts))
+                (< counter org-caldav-retry-attempts))
       (with-current-buffer
-	  (org-caldav-url-retrieve-synchronously
-	   (concat (org-caldav-events-url) (url-hexify-string uid) org-caldav-uuid-extension))
-	(goto-char (point-min))
-	(if (looking-at "HTTP.*2[0-9][0-9]")
-	    (setq eventbuffer (current-buffer))
-	  ;; There was an error retrieving the event
-	  (setq errormessage (buffer-substring (point-min) (point-at-eol)))
-	  (setq counter (1+ counter))
-	  (org-caldav-debug-print
-	   1 (format "(Try %d) Error when trying to retrieve UID %s: %s"
-		     counter uid errormessage)))))
+          (org-caldav-url-retrieve-synchronously
+           (concat (org-caldav-events-url) (url-hexify-string uid) org-caldav-uuid-extension))
+        (goto-char (point-min))
+        (if (looking-at "HTTP.*2[0-9][0-9]")
+            (setq eventbuffer (current-buffer))
+          ;; There was an error retrieving the event
+          (setq errormessage (buffer-substring (point-min) (point-at-eol)))
+          (setq counter (1+ counter))
+          (org-caldav-debug-print
+           1 (format "(Try %d) Error when trying to retrieve UID %s: %s"
+                     counter uid errormessage)))))
     (unless eventbuffer
       ;; Give up
       (error "Failed to retrieve UID %s after %d tries with error %s"
-	     uid org-caldav-retry-attempts errormessage))
+             uid org-caldav-retry-attempts errormessage))
     (with-current-buffer eventbuffer
       (unless (search-forward "BEGIN:VCALENDAR" nil t)
-	(error "Failed to find calendar entry for UID %s (see buffer %s)"
-	       uid (buffer-name eventbuffer)))
+        (error "Failed to find calendar entry for UID %s (see buffer %s)"
+               uid (buffer-name eventbuffer)))
       (beginning-of-line)
       (unless with-headers
-	(delete-region (point-min) (point)))
+        (delete-region (point-min) (point)))
       (save-excursion
-	(while (re-search-forward "\^M" nil t)
-	  (replace-match "")))
+        (while (re-search-forward "\^M" nil t)
+          (replace-match "")))
       ;; Join lines because of bug in icalendar parsing.
       (save-excursion
-	(while (re-search-forward "^ " nil t)
-	  (delete-char -2)))
+        (while (re-search-forward "^ " nil t)
+          (delete-char -2)))
       (org-caldav-debug-print 2 (format "Content of event UID %s: " uid)
-			      (buffer-string)))
+                              (buffer-string)))
     eventbuffer))
+
+(defun org-caldav-convert-buffer-to-crlf ()
+  "Converts local buffer to the dos format using crlf at the end
+  of the line.  Some ical validators fail otherwise."
+  (save-excursion
+    (goto-char (point-min))
+    (while (not (= (point) (point-max)))
+      (goto-char (- (point-at-eol) 1))
+      (unless (string= (thing-at-point 'char) "\^M")
+        (forward-char)
+        (insert "\^M"))
+      (forward-line))))
 
 (defun org-caldav-put-event (buffer)
   "Add event in BUFFER to calendar.
@@ -526,14 +582,14 @@ The filename will be derived from the UID."
       (insert org-caldav-calendar-preamble event "END:VCALENDAR\n")
       (goto-char (point-min))
       (let* ((uid (org-caldav-get-uid))
-	     (url (concat (org-caldav-events-url) (url-hexify-string uid) org-caldav-uuid-extension)))
-	(org-caldav-debug-print 1 (format "Putting event UID %s." uid))
-	(org-caldav-debug-print 2 (format "Content of event UID %s: " uid)
-				(buffer-string))
-	(setq org-caldav-empty-calendar nil)
-	(org-caldav-save-resource
-	 (concat (org-caldav-events-url) uid org-caldav-uuid-extension)
-	 (encode-coding-string (buffer-string) 'utf-8))))))
+             (url (concat (org-caldav-events-url) (url-hexify-string uid) org-caldav-uuid-extension)))
+        (org-caldav-debug-print 1 (format "Putting event UID %s." uid))
+        (org-caldav-debug-print 2 (format "Content of event UID %s: " uid)
+                                (buffer-string))
+        (setq org-caldav-empty-calendar nil)
+        (org-caldav-save-resource
+         (concat (org-caldav-events-url) uid org-caldav-uuid-extension)
+         (encode-coding-string (buffer-string) 'utf-8))))))
 
 (defun org-caldav-url-dav-delete-file (url)
   "Delete URL.
@@ -547,9 +603,9 @@ be caught and a message displayed instead."
   (org-caldav-debug-print 1 (format "Deleting event UID %s." uid))
   (condition-case err
       (progn
-	(org-caldav-url-dav-delete-file
-	 (concat (org-caldav-events-url) uid org-caldav-uuid-extension))
-	t)
+        (org-caldav-url-dav-delete-file
+         (concat (org-caldav-events-url) uid org-caldav-uuid-extension))
+        t)
     (error
      (progn
        (message "Could not delete URI %s." uid)
@@ -565,19 +621,19 @@ so you don't do it by accident."
   (if (not prefix)
       (message "This function has to be called with a prefix.")
     (unless (or org-caldav-empty-calendar
-		(not (y-or-n-p "This will delete EVERYTHING in your calendar. \
+                (not (y-or-n-p "This will delete EVERYTHING in your calendar. \
 Are you really sure? ")))
       (let ((events (org-caldav-get-event-etag-list))
-	    (counter 0)
-	    (url-show-status nil))
-	(dolist (cur events)
-	  (setq counter (1+ counter))
-	  (message "Deleting event %d of %d" counter (length events))
-	  (org-caldav-delete-event (car cur)))
-	(setq org-caldav-empty-calendar t))
+            (counter 0)
+            (url-show-status nil))
+        (dolist (cur events)
+          (setq counter (1+ counter))
+          (message "Deleting event %d of %d" counter (length events))
+          (org-caldav-delete-event (car cur)))
+        (setq org-caldav-empty-calendar t))
       (when (file-exists-p
-	     (org-caldav-sync-state-filename org-caldav-calendar-id))
-	(delete-file (org-caldav-sync-state-filename org-caldav-calendar-id)))
+             (org-caldav-sync-state-filename org-caldav-calendar-id))
+        (delete-file (org-caldav-sync-state-filename org-caldav-calendar-id)))
       (setq org-caldav-event-list nil)
       (setq org-caldav-sync-result nil)
       (message "Done"))))
@@ -585,15 +641,15 @@ Are you really sure? ")))
 (defun org-caldav-events-url ()
   "Return URL for events."
   (let* ((url
-	  (if (org-caldav-use-oauth2)
-	      (nth 4 (assoc org-caldav-url org-caldav-oauth2-providers))
-	    org-caldav-url))
-	 (eventsurl
-	  (if (string-match ".*%s.*" url)
-	      (format url org-caldav-calendar-id)
-	    (concat url "/" org-caldav-calendar-id "/"))))
+          (if (org-caldav-use-oauth2)
+              (nth 4 (assoc org-caldav-url org-caldav-oauth2-providers))
+            org-caldav-url))
+         (eventsurl
+          (if (string-match ".*%s.*" url)
+              (format url org-caldav-calendar-id)
+            (concat url "/" org-caldav-calendar-id "/"))))
     (if (string-match ".*/$" eventsurl)
-	eventsurl
+        eventsurl
       (concat eventsurl "/"))))
 
 (defun org-caldav-update-eventdb-from-org (buf)
@@ -603,31 +659,31 @@ Are you really sure? ")))
     (goto-char (point-min))
     (while (org-caldav-narrow-next-event)
       (let* ((uid (org-caldav-rewrite-uid-in-event))
-	     (md5 (unless (string-match "^orgsexp-" uid)
-		    (org-caldav-generate-md5-for-org-entry uid)))
-	     (event (org-caldav-search-event uid)))
-	(cond
-	 ((null event)
-	  ;; Event does not yet exist in DB, so add it.
-	  (org-caldav-debug-print 1
-	   (format "Org UID %s: New" uid))
-	  (org-caldav-add-event uid md5 nil nil 'new-in-org))
-	 ((not (string= md5 (org-caldav-event-md5 event)))
-	  ;; Event exists but has changed MD5, so mark it as changed.
-	  (org-caldav-debug-print 1
-	   (format "Org UID %s: Changed" uid))
-	  (org-caldav-event-set-md5 event md5)
-	  (org-caldav-event-set-status event 'changed-in-org))
-	 ((eq (org-caldav-event-status event) 'new-in-org)
-	  (org-caldav-debug-print 1
-	   (format "Org UID %s: Error. Double entry." uid))
-	  (push (list org-caldav-calendar-id
-		      uid 'new-in-org 'error:double-entry)
-		org-caldav-sync-result))
-	 (t
-	  (org-caldav-debug-print 1
-	   (format "Org UID %s: Synced" uid))
-	  (org-caldav-event-set-status event 'in-org)))))
+             (md5 (unless (string-match "^orgsexp-" uid)
+                    (org-caldav-generate-md5-for-org-entry uid)))
+             (event (org-caldav-search-event uid)))
+        (cond
+         ((null event)
+          ;; Event does not yet exist in DB, so add it.
+          (org-caldav-debug-print 1
+           (format "Org UID %s: New" uid))
+          (org-caldav-add-event uid md5 nil nil 'new-in-org))
+         ((not (string= md5 (org-caldav-event-md5 event)))
+          ;; Event exists but has changed MD5, so mark it as changed.
+          (org-caldav-debug-print 1
+           (format "Org UID %s: Changed" uid))
+          (org-caldav-event-set-md5 event md5)
+          (org-caldav-event-set-status event 'changed-in-org))
+         ((eq (org-caldav-event-status event) 'new-in-org)
+          (org-caldav-debug-print 1
+           (format "Org UID %s: Error. Double entry." uid))
+          (push (list org-caldav-calendar-id
+                      uid 'new-in-org 'error:double-entry)
+                org-caldav-sync-result))
+         (t
+          (org-caldav-debug-print 1
+           (format "Org UID %s: Synced" uid))
+          (org-caldav-event-set-status event 'in-org)))))
     ;; Mark events deleted in Org
     (dolist (cur (org-caldav-filter-events nil))
       (org-caldav-debug-print
@@ -638,44 +694,44 @@ Are you really sure? ")))
   "Update event database from calendar."
   (org-caldav-debug-print 1 "=== Updating EventDB from Cal")
   (let ((events (org-caldav-get-event-etag-list))
-	dbentry)
+        dbentry)
     (dolist (cur events)
       ;; Search entry in database.
       (setq dbentry (org-caldav-search-event (car cur)))
       (cond
        ((not dbentry)
-	;; Event is not yet in database, so add it.
-	(org-caldav-debug-print 1
-	 (format "Cal UID %s: New" (car cur)))
-	(org-caldav-add-event (car cur) nil (cdr cur) nil 'new-in-cal))
+        ;; Event is not yet in database, so add it.
+        (org-caldav-debug-print 1
+         (format "Cal UID %s: New" (car cur)))
+        (org-caldav-add-event (car cur) nil (cdr cur) nil 'new-in-cal))
        ((or (eq (org-caldav-event-status dbentry) 'changed-in-org)
-	    (eq (org-caldav-event-status dbentry) 'deleted-in-org))
-	(org-caldav-debug-print 1
-	 (format "Cal UID %s: Ignoring (Org always wins)." (car cur))))
+            (eq (org-caldav-event-status dbentry) 'deleted-in-org))
+        (org-caldav-debug-print 1
+         (format "Cal UID %s: Ignoring (Org always wins)." (car cur))))
        ((null (org-caldav-event-etag dbentry))
-	(org-caldav-debug-print 1
-	 (format "Cal UID %s: No Etag. Mark as change, so putting it again." (car cur)))
-	(org-caldav-event-set-status dbentry 'changed-in-org))
+        (org-caldav-debug-print 1
+         (format "Cal UID %s: No Etag. Mark as change, so putting it again." (car cur)))
+        (org-caldav-event-set-status dbentry 'changed-in-org))
        ((not (string= (cdr cur) (org-caldav-event-etag dbentry)))
-	;; Event's etag changed.
-	(org-caldav-debug-print 1
-	 (format "Cal UID %s: Changed" (car cur)))
-	(org-caldav-event-set-status dbentry 'changed-in-cal)
-	(org-caldav-event-set-etag dbentry (cdr cur)))
+        ;; Event's etag changed.
+        (org-caldav-debug-print 1
+         (format "Cal UID %s: Changed" (car cur)))
+        (org-caldav-event-set-status dbentry 'changed-in-cal)
+        (org-caldav-event-set-etag dbentry (cdr cur)))
        ((null (org-caldav-event-status dbentry))
-	;; Event was deleted in Org
-	(org-caldav-debug-print 1
-	 (format "Cal UID %s: Deleted in Org" (car cur)))
-	(org-caldav-event-set-status dbentry 'deleted-in-org))
+        ;; Event was deleted in Org
+        (org-caldav-debug-print 1
+         (format "Cal UID %s: Deleted in Org" (car cur)))
+        (org-caldav-event-set-status dbentry 'deleted-in-org))
        ((eq (org-caldav-event-status dbentry) 'in-org)
-	(org-caldav-debug-print 1
-	 (format "Cal UID %s: Synced" (car cur)))
-	(org-caldav-event-set-status dbentry 'synced))
+        (org-caldav-debug-print 1
+         (format "Cal UID %s: Synced" (car cur)))
+        (org-caldav-event-set-status dbentry 'synced))
        ((eq (org-caldav-event-status dbentry) 'changed-in-org)
-	;; Do nothing
-	)
+        ;; Do nothing
+        )
        (t
-	(error "Unknown status; this is probably a bug."))))
+        (error "Unknown status; this is probably a bug."))))
     ;; Mark events deleted in cal.
     (dolist (cur (org-caldav-filter-events 'in-org))
       (org-caldav-debug-print 1
@@ -690,8 +746,8 @@ Are you really sure? ")))
     (with-current-buffer (marker-buffer marker)
       (goto-char (marker-position marker))
       (md5 (buffer-substring-no-properties
-	    (org-entry-beginning-position)
-	    (org-entry-end-position))))))
+            (org-entry-beginning-position)
+            (org-entry-end-position))))))
 
 (defun org-caldav-var-for-key (key)
   "Return associated global org-caldav variable for key KEY."
@@ -704,8 +760,8 @@ Are you really sure? ")))
     (:inbox 'org-caldav-inbox)
     (:skip-conditions 'org-caldav-skip-conditions)
     (t (intern
-	(concat "org-"
-		(substring (symbol-name key) 1))))))
+        (concat "org-"
+                (substring (symbol-name key) 1))))))
 
 (defun org-caldav-sync-calendar (&optional calendar resume)
   "Sync one calendar, optionally provided through plist CALENDAR.
@@ -717,59 +773,59 @@ If RESUME is non-nil, try to resume."
     ;; Extrace keys and values from 'calendar' for progv binding.
     (dolist (i (number-sequence 0 (1- (length calendar)) 2))
       (setq calkeys (append calkeys (list (nth i calendar)))
-	    calvalues (append calvalues (list (nth (1+ i) calendar)))))
+            calvalues (append calvalues (list (nth (1+ i) calendar)))))
     (cl-progv (mapcar 'org-caldav-var-for-key calkeys) calvalues
       (dolist (filename (append org-caldav-files
-				(list (org-caldav-inbox-file org-caldav-inbox))))
-	(when (not (file-exists-p filename))
-	  (user-error "File %s does not exist" filename)))
+                                (list (org-caldav-inbox-file org-caldav-inbox))))
+        (when (not (file-exists-p filename))
+          (user-error "File %s does not exist" filename)))
       ;; Check if we need to do OAuth2
       (when (org-caldav-use-oauth2)
-	;; We need to do oauth2. Check if it is available.
-	(org-caldav-check-oauth2 org-caldav-url)
-	;; Retrieve token
-	(org-caldav-retrieve-oauth2-token org-caldav-url org-caldav-calendar-id))
+        ;; We need to do oauth2. Check if it is available.
+        (org-caldav-check-oauth2 org-caldav-url)
+        ;; Retrieve token
+        (org-caldav-retrieve-oauth2-token org-caldav-url org-caldav-calendar-id))
       (let ((numretry 0)
-	    success)
-	(while (null success)
-	  (condition-case err
-	      (progn
-		(org-caldav-check-connection)
-		(setq success t))
-	    (error
-	     (if (= numretry (1- org-caldav-retry-attempts))
-		 (org-caldav-check-connection)
-	       (org-caldav-debug-print
-		1 "Got error while checking connection (will try again):" err)
-	       (cl-incf numretry))))))
+            success)
+        (while (null success)
+          (condition-case err
+              (progn
+                (org-caldav-check-connection)
+                (setq success t))
+            (error
+             (if (= numretry (1- org-caldav-retry-attempts))
+                 (org-caldav-check-connection)
+               (org-caldav-debug-print
+                1 "Got error while checking connection (will try again):" err)
+               (cl-incf numretry))))))
       (unless resume
-	(setq org-caldav-ics-buffer (org-caldav-generate-ics))
-	(setq org-caldav-event-list nil
-	      org-caldav-previous-files nil)
-	(org-caldav-load-sync-state)
-	;; Check if org files were removed.
-	(when org-caldav-previous-files
-	  (let ((missing (cl-set-difference org-caldav-previous-files
-					    org-caldav-files
-					    :test #'string=)))
-	    (when (and missing
-		       (not (yes-or-no-p
-			     (concat "WARNING: Previously synced file(s) are missing: "
-				     (mapconcat 'identity missing ",")
-				     "%s. Are you sure you want to sync? "))))
-	      (user-error "Sync aborted"))))
-	;; Remove status in event list
-	(dolist (cur org-caldav-event-list)
-	  (org-caldav-event-set-status cur nil))
-	(org-caldav-update-eventdb-from-org org-caldav-ics-buffer)
-	(org-caldav-update-eventdb-from-cal))
+        (setq org-caldav-ics-buffer (org-caldav-generate-ics))
+        (setq org-caldav-event-list nil
+              org-caldav-previous-files nil)
+        (org-caldav-load-sync-state)
+        ;; Check if org files were removed.
+        (when org-caldav-previous-files
+          (let ((missing (cl-set-difference org-caldav-previous-files
+                                            org-caldav-files
+                                            :test #'string=)))
+            (when (and missing
+                       (not (yes-or-no-p
+                             (concat "WARNING: Previously synced file(s) are missing: "
+                                     (mapconcat 'identity missing ",")
+                                     "%s. Are you sure you want to sync? "))))
+              (user-error "Sync aborted"))))
+        ;; Remove status in event list
+        (dolist (cur org-caldav-event-list)
+          (org-caldav-event-set-status cur nil))
+        (org-caldav-update-eventdb-from-org org-caldav-ics-buffer)
+        (org-caldav-update-eventdb-from-cal))
       (org-caldav-update-events-in-cal org-caldav-ics-buffer)
       (org-caldav-update-events-in-org)
       (org-caldav-save-sync-state)
       (setq org-caldav-event-list nil)
       (with-current-buffer org-caldav-ics-buffer
-	(set-buffer-modified-p nil)
-	(kill-buffer))
+        (set-buffer-modified-p nil)
+        (kill-buffer))
       (delete-file (buffer-file-name org-caldav-ics-buffer)))))
 
 ;;;###autoload
@@ -777,23 +833,23 @@ If RESUME is non-nil, try to resume."
   "Sync Org with calendar."
   (interactive)
   (unless (or (> emacs-major-version 24)
-	      (and (= emacs-major-version 24)
-		   (> emacs-minor-version 2)))
+              (and (= emacs-major-version 24)
+                   (> emacs-minor-version 2)))
     (user-error "You have to use at least Emacs 24.3"))
   (org-caldav-debug-print 1 "========== Started sync.")
   (if (and org-caldav-event-list
-	   (not (eq org-caldav-resume-aborted 'never))
-	   (or (eq org-caldav-resume-aborted 'always)
-	       (and (eq org-caldav-resume-aborted 'ask))
-	       (y-or-n-p "Last sync seems to have been aborted. \
+           (not (eq org-caldav-resume-aborted 'never))
+           (or (eq org-caldav-resume-aborted 'always)
+               (and (eq org-caldav-resume-aborted 'ask))
+               (y-or-n-p "Last sync seems to have been aborted. \
 Should I try to resume? ")))
       (org-caldav-sync-calendar org-caldav-previous-calendar t)
     (setq org-caldav-sync-result nil)
     (if (null org-caldav-calendars)
-	(org-caldav-sync-calendar)
+        (org-caldav-sync-calendar)
       (dolist (calendar org-caldav-calendars)
-	(org-caldav-debug-print 1 "Syncing first calendar entry:" calendar)
-	(org-caldav-sync-calendar calendar))))
+        (org-caldav-debug-print 1 "Syncing first calendar entry:" calendar)
+        (org-caldav-sync-calendar calendar))))
   (when org-caldav-show-sync-results
     (org-caldav-display-sync-results))
   (message "Finished sync."))
@@ -806,70 +862,75 @@ ICSBUF is the buffer containing the exported iCalendar file."
     (widen)
     (goto-char (point-min))
     (let ((events (append (org-caldav-filter-events 'new-in-org)
-			  (org-caldav-filter-events 'changed-in-org)))
-	  (counter 0)
-	  (url-show-status nil)
-	  (event-etag (org-caldav-get-event-etag-list))
-	  uid)
+                          (org-caldav-filter-events 'changed-in-org)))
+          (counter 0)
+          (url-show-status nil)
+          (event-etag (org-caldav-get-event-etag-list))
+          uid)
       ;; Put the events via CalDAV.
       (dolist (cur events)
-	(setq counter (1+ counter))
-	(if (eq (org-caldav-event-etag cur) 'put)
-	    (org-caldav-debug-print 1
-	     (format "Event UID %s: Was already put previously." (car cur)))
-	  (org-caldav-debug-print 1
-	   (format "Event UID %s: Org --> Cal" (car cur)))
-	  (widen)
-	  (goto-char (point-min))
-	  (while (and (setq uid (org-caldav-get-uid))
-		      (not (string-match (car cur) uid))))
-	  (unless (string-match (car cur) uid)
-	    (error "Could not find UID %s" (car cur)))
-	  (org-caldav-narrow-event-under-point)
-	  (org-caldav-cleanup-ics-description)
-	  (org-caldav-maybe-fix-timezone)
-	  (org-caldav-set-sequence-number cur event-etag)
-	  (message "Putting event %d of %d" counter (length events))
-	  (if (org-caldav-put-event icsbuf)
-	      (org-caldav-event-set-etag cur 'put)
-	    (org-caldav-debug-print 1
-	     (format "Event UID %s: Error while doing Org --> Cal" (car cur)))
-	    (org-caldav-event-set-status cur 'error)
-	    (push (list org-caldav-calendar-id (car cur)
-			'error 'error:org->cal)
-		  org-caldav-sync-result))))
+        (setq counter (1+ counter))
+        (if (eq (org-caldav-event-etag cur) 'put)
+            (org-caldav-debug-print 1
+             (format "Event UID %s: Was already put previously." (car cur)))
+          (org-caldav-debug-print 1
+           (format "Event UID %s: Org --> Cal" (car cur)))
+          (widen)
+          (goto-char (point-min))
+          (while (and (setq uid (org-caldav-get-uid))
+                      (not (string-match (car cur) uid))))
+          (unless (string-match (car cur) uid)
+            (error "Could not find UID %s" (car cur)))
+          (org-caldav-narrow-event-under-point)
+          (org-caldav-cleanup-ics-description)
+          (org-caldav-maybe-fix-timezone)
+          (org-caldav-set-sequence-number cur event-etag)
+          (org-caldav-fix-todo-priority)
+          (org-caldav-fix-todo-status-percent-state)
+          (org-caldav-fix-categories)
+          (org-caldav-fix-todo-dtstart)
+          (org-caldav-convert-buffer-to-crlf)
+          (message "Putting event %d of %d" counter (length events))
+          (if (org-caldav-put-event icsbuf)
+              (org-caldav-event-set-etag cur 'put)
+            (org-caldav-debug-print 1
+             (format "Event UID %s: Error while doing Org --> Cal" (car cur)))
+            (org-caldav-event-set-status cur 'error)
+            (push (list org-caldav-calendar-id (car cur)
+                        'error 'error:org->cal)
+                  org-caldav-sync-result))))
       ;; Get Etags
       (setq event-etag (org-caldav-get-event-etag-list))
       (dolist (cur events)
-	(let ((etag (assoc (car cur) event-etag)))
-	  (when (and (not (eq (org-caldav-event-status cur) 'error))
-		     etag)
-	    (org-caldav-event-set-etag cur (cdr etag))
-	    (push (list org-caldav-calendar-id (car cur)
-			(org-caldav-event-status cur) 'org->cal)
-		  org-caldav-sync-result)))))
+        (let ((etag (assoc (car cur) event-etag)))
+          (when (and (not (eq (org-caldav-event-status cur) 'error))
+                     etag)
+            (org-caldav-event-set-etag cur (cdr etag))
+            (push (list org-caldav-calendar-id (car cur)
+                        (org-caldav-event-status cur) 'org->cal)
+                  org-caldav-sync-result)))))
     ;; Remove events that were deleted in org
     (unless (eq org-caldav-delete-calendar-entries 'never)
       (let ((events (org-caldav-filter-events 'deleted-in-org))
-	    (url-show-status nil)
-	    (counter 0))
-	(dolist (cur events)
-	  (setq counter (1+ counter))
-	  (when (or (eq org-caldav-delete-calendar-entries 'always)
-		    (y-or-n-p (format "Delete event '%s' from calendar?"
-				       (org-caldav-get-calendar-summary-from-uid
-					(car cur)))))
-	    (message "Deleting event %d from %d" counter (length events))
-	    (org-caldav-delete-event (car cur))
-	    (push (list org-caldav-calendar-id (car cur)
-			'deleted-in-org 'removed-from-cal)
-		  org-caldav-sync-result)
-	    (setq org-caldav-event-list
-		  (delete cur org-caldav-event-list))))))
+            (url-show-status nil)
+            (counter 0))
+        (dolist (cur events)
+          (setq counter (1+ counter))
+          (when (or (eq org-caldav-delete-calendar-entries 'always)
+                    (y-or-n-p (format "Delete event '%s' from calendar?"
+                                       (org-caldav-get-calendar-summary-from-uid
+                                        (car cur)))))
+            (message "Deleting event %d from %d" counter (length events))
+            (org-caldav-delete-event (car cur))
+            (push (list org-caldav-calendar-id (car cur)
+                        'deleted-in-org 'removed-from-cal)
+                  org-caldav-sync-result)
+            (setq org-caldav-event-list
+                  (delete cur org-caldav-event-list))))))
     ;; Remove events that could not be put
     (dolist (cur (org-caldav-filter-events 'error))
       (setq org-caldav-event-list
-	    (delete cur org-caldav-event-list)))))
+            (delete cur org-caldav-event-list)))))
 
 (defun org-caldav-set-sequence-number (event event-etag)
   "Set sequence number in ics and in eventdb for EVENT.
@@ -877,34 +938,34 @@ EVENT-ETAG is the current list of events and etags on the server.
 The ics must be in the current buffer."
   (save-excursion
     (let ((seq (org-caldav-event-sequence event))
-	  retrieve)
+          retrieve)
       (unless (or seq
-		  (not (assoc (car event) event-etag)))
-	;; We don't have a sequence yet, but event is already in the
-	;; calendar, hence we have to get the current number first.
-	(setq retrieve (org-caldav-get-event (car event)))
-	(when (null retrieve)
-	  ;; Retrieving the event failed... so let's just use '1' and
-	  ;; hope it works.
-	  (org-caldav-debug-print 1 "UID %s: Failed to retrieve item from server." (car event))
-	  (org-caldav-debug-print 1 "UID %s: Use sequence number 1 and hope for the best." (car event))
-	  (setq seq 1))
-	(unless seq
-	  (with-current-buffer (org-caldav-get-event (car event))
-	    (goto-char (point-min))
-	    (when (re-search-forward "^SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
-	      (org-caldav-event-set-sequence
-	       event (string-to-number (match-string 1))))
-	    (setq seq (org-caldav-event-sequence event))
-	    (org-caldav-debug-print 1 "UID %s: Got sequence number %d" (car event) seq))))
+                  (not (assoc (car event) event-etag)))
+        ;; We don't have a sequence yet, but event is already in the
+        ;; calendar, hence we have to get the current number first.
+        (setq retrieve (org-caldav-get-event (car event)))
+        (when (null retrieve)
+          ;; Retrieving the event failed... so let's just use '1' and
+          ;; hope it works.
+          (org-caldav-debug-print 1 "UID %s: Failed to retrieve item from server." (car event))
+          (org-caldav-debug-print 1 "UID %s: Use sequence number 1 and hope for the best." (car event))
+          (setq seq 1))
+        (unless seq
+          (with-current-buffer (org-caldav-get-event (car event))
+            (goto-char (point-min))
+            (when (re-search-forward "^SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
+              (org-caldav-event-set-sequence
+               event (string-to-number (match-string 1))))
+            (setq seq (org-caldav-event-sequence event))
+            (org-caldav-debug-print 1 (format "UID %s: Got sequence number " (car event)) seq))))
       (when seq
-	(setq seq (1+ seq))
-	(goto-char (point-min))
-	(re-search-forward "^SUMMARY:")
-	(forward-line)
-	(beginning-of-line)
-	(insert "SEQUENCE:" (number-to-string seq) "\n")
-	(org-caldav-event-set-sequence event seq)))))
+        (setq seq (1+ seq))
+        (goto-char (point-min))
+        (re-search-forward "^SEQUENCE:")
+        (delete-region (point-at-bol) (+ 1 (point-at-eol)))
+        (beginning-of-line)
+        (insert "SEQUENCE:" (number-to-string seq) "\n")
+        (org-caldav-event-set-sequence event seq)))))
 
 (defun org-caldav-cleanup-ics-description ()
   "Cleanup description for event in current buffer.
@@ -922,156 +983,246 @@ This is a bug in older Org versions."
     (save-excursion
       (goto-char (point-min))
       (while (search-forward (upcase org-icalendar-timezone) nil t)
-	(replace-match org-icalendar-timezone t)))))
+        (replace-match org-icalendar-timezone t)))))
+
+(defun org-caldav-fix-todo-priority ()
+  "icalendar exports default priority with ical export.  We want
+  a priority of 0 if is not set."
+  (save-excursion
+    (goto-char (point-min))
+    (when (search-forward "BEGIN:VTODO" nil t)
+      (search-forward "PRIORITY:")
+      (unless (eq (thing-at-point 'number) 0)
+        (delete-region (point) (- (point-at-eol) 1))
+        (insert (number-to-string
+                  (save-excursion
+                    (goto-char (point-min))
+                    (org-id-goto (org-caldav-get-uid))
+                    (if (re-search-forward org-priority-regexp nil t)
+                      (let ((prio (org-entry-get nil "PRIORITY")))
+                        (dolist (pri org-caldav-todo-priority r)
+                          (when (string= (car (cdr pri)) prio)
+                            (setq r (car pri)))))
+                      0))))))))
+
+(defun org-caldav-fix-todo-status-percent-state ()
+  "icalendar exports only sets the STATUS but not the
+PERCENT-COMPLETE.  This works great if you have only TODO and
+DONE, but I like to use other states like STARTED or NEXT to
+indicate the process.  This fixes the ical values for that.
+
+TODO: save percent-complete also as a property in org"
+  (save-excursion
+    (goto-char (point-min))
+    (when (search-forward "BEGIN:VTODO" nil t)
+      (if (search-forward "STATUS:" nil t)
+        (delete-region (point-at-bol) (+ 1 (point-at-eol)))
+        (progn (search-forward "END:VTODO")
+          (goto-char (point-at-bol))))
+
+
+      (let* ((state (save-excursion
+                      (goto-char (point-min))
+                      (org-id-goto (org-caldav-get-uid))
+                      (substring-no-properties (org-get-todo-state))))
+              (percent (dolist (p org-caldav-todo-percent-states r)
+                         (when (string= state (car (cdr p)))
+                           (setq r (car p)))))
+              (status (cond ((= percent 0) "NEEDS-ACTION")
+                        ((= percent 100) "COMPLETED")
+                        (t "IN-PROCESS")))
+              (completed (save-excursion
+                           (goto-char (point-min))
+                           (org-id-goto (org-caldav-get-uid))
+                           (org-element-property :closed (org-element-at-point)))))
+        (insert "PERCENT-COMPLETE:" (number-to-string percent) "\n")
+        (insert "STATUS:" status "\n")
+        ;; if closed missing but in DONE state:
+        (when (and (= percent 100) (not completed))
+          (setq completed (save-excursion
+                            (goto-char (point-min))
+                            (org-id-goto (org-caldav-get-uid))
+                            (org-add-planning-info 'closed (org-current-effective-time))
+                            (org-element-property :closed (org-element-at-point))))
+          )
+        (when completed
+          (insert (org-icalendar-convert-timestamp
+                    completed "COMPLETED") "\n"))))))
+
+
+(defun org-caldav-fix-categories ()
+  "Nextcloud creates an empty category if this is set without any
+  entry.  We fix this by removing the CATEGORIES entry."
+  (save-excursion
+    (goto-char (point-min))
+    (when (and (search-forward "CATEGORIES:" nil t)
+            (not (thing-at-point 'word)))
+      (delete-region (point-at-bol) (+ (point-at-eol) 1)))))
+
+(defun org-caldav-fix-todo-dtstart ()
+  "ox-icalendar includes the actual time as DTSTART into the
+vtodo.  For nextcloud this behaviour is undesired, because
+dtstart is used for the beginning of the task, which is in the
+SCHEDULED of the org entry.  Lets see if the org entry has a
+scheduled time and remove dtstart if it doesn't."
+  (save-excursion
+    (goto-char (point-min))
+    (when (search-forward "BEGIN:VTODO" nil t)
+      (when
+        (search-forward "DTSTART" nil t)
+        (unless
+          (save-excursion
+            (goto-char (point-min))
+            (org-id-goto (org-caldav-get-uid))
+            (org-get-scheduled-time nil))
+          (delete-region (point-at-bol) (+ 1 (point-at-eol))))))))
 
 (defun org-caldav-inbox-file (inbox)
   "Return file name associated with INBOX.
 For format of INBOX, see `org-caldav-inbox'."
   (cond ((stringp inbox)
-	 inbox)
-	((memq (car inbox) '(file file+headline))
-	 (nth 1 inbox))
-	((eq (car inbox) 'id)
-	 (org-id-find-id-file (nth 1 inbox)))))
+         inbox)
+        ((memq (car inbox) '(file file+headline))
+         (nth 1 inbox))
+        ((eq (car inbox) 'id)
+         (org-id-find-id-file (nth 1 inbox)))))
 
 (defun org-caldav-inbox-point-and-level (inbox)
   "Return position and level where to add new entries in INBOX.
 For format of INBOX, see `org-caldav-inbox'.  The values are
 returned as a cons (POINT . LEVEL)."
   (cond ((or (stringp inbox) (eq (car inbox) 'file))
-	 (cons (point-max) 1))
-	((eq (car inbox) 'file+headline)
-	 (save-excursion
-	   (let ((org-link-search-inhibit-query t)
-		 level)
-	     ;; org-link-search changed signature in v8.3
-	     (with-no-warnings
-	       (if (version< org-version "8.3")
-		   (org-link-search (concat "*" (nth 2 inbox)) nil nil t)
-		 (org-link-search (concat "*" (nth 2 inbox)) nil t)))
-	     (setq level (1+ (org-current-level)))
-	     (org-end-of-subtree t t)
-	     (cons (point) level))))
-	((eq (car inbox) 'id)
-	 (save-excursion
-	   (goto-char (cdr (org-id-find (nth 1 inbox))))
-	   (let ((level (1+ (org-current-level))))
-	     (org-end-of-subtree t t)
-	     (cons (point) level))))))
+         (cons (point-max) 1))
+        ((eq (car inbox) 'file+headline)
+         (save-excursion
+           (let ((org-link-search-inhibit-query t)
+                 level)
+             ;; org-link-search changed signature in v8.3
+             (with-no-warnings
+               (if (version< org-version "8.3")
+                   (org-link-search (concat "*" (nth 2 inbox)) nil nil t)
+                 (org-link-search (concat "*" (nth 2 inbox)) nil t)))
+             (setq level (1+ (org-current-level)))
+             (org-end-of-subtree t t)
+             (cons (point) level))))
+        ((eq (car inbox) 'id)
+         (save-excursion
+           (goto-char (cdr (org-id-find (nth 1 inbox))))
+           (let ((level (1+ (org-current-level))))
+             (org-end-of-subtree t t)
+             (cons (point) level))))))
 
 (defun org-caldav-update-events-in-org ()
   "Update events in Org files."
   (org-caldav-debug-print 1 "=== Updating events in Org")
   (let ((events (append (org-caldav-filter-events 'new-in-cal)
-			(org-caldav-filter-events 'changed-in-cal)))
-	(url-show-status nil)
-	(counter 0)
-	eventdata buf uid timesync)
+                        (org-caldav-filter-events 'changed-in-cal)))
+        (url-show-status nil)
+        (counter 0)
+        eventdata buf uid timesync vevent vtodo)
 
     (dolist (cur events)
       (catch 'next
-	(setq uid (car cur))
-	(setq counter (1+ counter))
-	(message "Getting event %d of %d" counter (length events))
-	(with-current-buffer (org-caldav-get-event uid)
-	  ;; Get sequence number
-	  (goto-char (point-min))
-	  (save-excursion
-	    (when (re-search-forward "^SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
-	      (org-caldav-event-set-sequence
-	       cur (string-to-number (match-string 1)))))
-	  (setq eventdata (org-caldav-convert-event)))
-	(cond
-	 ((eq (org-caldav-event-status cur) 'new-in-cal)
-	  ;; This is a new event.
-	  (condition-case nil
-	      (with-current-buffer (find-file-noselect
-				    (org-caldav-inbox-file org-caldav-inbox))
-		(let ((point-and-level (org-caldav-inbox-point-and-level org-caldav-inbox)))
-		  (org-caldav-debug-print
-		   1 (format "Event UID %s: New in Cal --> Org inbox." uid))
-		  (goto-char (car point-and-level))
-		  (apply 'org-caldav-insert-org-entry
-			 (append eventdata (list uid (cdr point-and-level)))))
-		(push (list org-caldav-calendar-id uid
-			    (org-caldav-event-status cur) 'cal->org)
-		      org-caldav-sync-result)
-		(setq buf (current-buffer)))
-	    (error
-	     ;; inbox file/headline could not be found
-	     (org-caldav-event-set-status cur 'error)
-	     (push (list org-caldav-calendar-id uid
-			 (org-caldav-event-status cur) 'error:inbox-notfound)
-		   org-caldav-sync-result)
-	     (throw 'next nil))))
-	 ((string-match "^orgsexp-" uid)
-	  ;; This was generated by a org-sexp, we cannot sync it this way.
-	  (org-caldav-debug-print
-	   1 (format "Event UID %s: Changed in Cal, but this is a sexp entry \
+        (setq uid (car cur))
+        (setq counter (1+ counter))
+        (setq vtodo nil vevent nil)
+        (message "Getting event %d of %d" counter (length events))
+        (with-current-buffer (org-caldav-get-event uid)
+          ;; Get sequence number
+          (goto-char (point-min))
+          ;; set vevent or vtodo
+          (save-excursion
+            (when (re-search-forward "^BEGIN:VTODO$" nil t)
+              (when org-caldav-sync-todo
+                (setq vtodo t))
+              (org-caldav-debug-print 2 (format "This is a todo: %s" uid))
+              (unless org-caldav-sync-todo
+                (org-caldav-debug-print 2 "But org-caldav-sync-todo is nil."))))
+          (save-excursion
+            (when (re-search-forward "^BEGIN:VEVENT$" nil t)
+              (setq vevent t)
+              (org-caldav-debug-print 2 (format "This is a event: %s" uid))))
+          (save-excursion
+            (when (re-search-forward "^SEQUENCE:\\s-*\\([0-9]+\\)" nil t)
+              (org-caldav-event-set-sequence
+               cur (string-to-number (match-string 1)))))
+          (when vevent
+            (setq eventdata (org-caldav-convert-event)))
+          (when vtodo
+            (setq tododata (org-caldav-convert-todo))
+            (org-caldav-debug-print 2 tododata))
+          ;; stop here if not vevent or vtodo
+          (unless (or vevent vtodo)
+            (org-caldav-debug-print 1 (format "UID %s it neither vevent nor vtodo and cannot be processed." uid))
+            (throw 'next nil)))
+        (cond
+         ((eq (org-caldav-event-status cur) 'new-in-cal)
+          ;; This is a new event.
+          (condition-case nil
+              (with-current-buffer (find-file-noselect
+                                    (org-caldav-inbox-file org-caldav-inbox))
+                (let ((point-and-level (org-caldav-inbox-point-and-level org-caldav-inbox)))
+                  (org-caldav-debug-print
+                   1 (format "Event UID %s: New in Cal --> Org inbox." uid))
+                  (goto-char (car point-and-level))
+                  (when vevent
+                    (apply 'org-caldav-insert-org-entry
+                      (append eventdata (list uid (cdr point-and-level)))))
+                  (when vtodo
+                    (apply 'org-caldav-insert-org-todo
+                      (append tododata (list uid (cdr point-and-level))))))
+                (push (list org-caldav-calendar-id uid
+                            (org-caldav-event-status cur) 'cal->org)
+                      org-caldav-sync-result)
+                (setq buf (current-buffer)))
+            (error
+             ;; inbox file/headline could not be found
+             (org-caldav-event-set-status cur 'error)
+             (push (list org-caldav-calendar-id uid
+                         (org-caldav-event-status cur) 'error:inbox-notfound)
+                   org-caldav-sync-result)
+             (throw 'next nil))))
+         ((string-match "^orgsexp-" uid)
+          ;; This was generated by a org-sexp, we cannot sync it this way.
+          (org-caldav-debug-print
+           1 (format "Event UID %s: Changed in Cal, but this is a sexp entry \
 which can only be synced to calendar. Ignoring." uid))
-	  (org-caldav-event-set-status cur 'synced)
-	  (push (list org-caldav-calendar-id uid
-		      (org-caldav-event-status cur) 'error:changed-orgsexp)
-		org-caldav-sync-result)
-	  (throw 'next nil))
-	 (t
-	  ;; This is a changed event.
-	  (org-caldav-debug-print
-	   1 (format "Event UID %s: Changed in Cal --> Org" uid))
-	  (let ((marker (org-id-find (car cur) t)))
-	    (when (null marker)
-	      (error "Could not find UID %s." (car cur)))
-	    (with-current-buffer (marker-buffer marker)
-	      (goto-char (marker-position marker))
-	      (when org-caldav-backup-file
-		(org-caldav-backup-item))
-	      ;; See what we should sync.
-	      (when (or (eq org-caldav-sync-changes-to-org 'title-only)
-			(eq org-caldav-sync-changes-to-org 'title-and-timestamp))
-		;; Sync title
-		(org-caldav-change-heading (nth 4 eventdata)))
-	      (when (or (eq org-caldav-sync-changes-to-org 'timestamp-only)
-			(eq org-caldav-sync-changes-to-org 'title-and-timestamp))
-		;; Sync timestamp
-		(setq timesync
-		      (org-caldav-change-timestamp
-		       (apply 'org-caldav-create-time-range (butlast eventdata 2)))))
-	      (when (eq org-caldav-sync-changes-to-org 'all)
-		;; Sync everything, so first remove the old one.
-		(let ((level (org-current-level)))
-		  (delete-region (org-entry-beginning-position)
-				 (org-entry-end-position))
-		  (apply 'org-caldav-insert-org-entry
-			 (append eventdata (list uid level)))))
-	      (setq buf (current-buffer))
-	      (push (list org-caldav-calendar-id uid
-			  (org-caldav-event-status cur)
-			  (if (eq timesync 'orgsexp)
-			      'error:changed-orgsexp 'cal->org))
-		    org-caldav-sync-result)))))
-	;; Update the event database.
-	(org-caldav-event-set-status cur 'synced)
-	(with-current-buffer buf
-	  (org-caldav-event-set-md5
-	   cur (md5 (buffer-substring-no-properties
-		     (org-entry-beginning-position)
-		     (org-entry-end-position))))))))
+          (org-caldav-event-set-status cur 'synced)
+          (push (list org-caldav-calendar-id uid
+                      (org-caldav-event-status cur) 'error:changed-orgsexp)
+                org-caldav-sync-result)
+          (throw 'next nil))
+         (t
+          ;; This is a changed event.
+          (org-caldav-debug-print
+           1 (format "Event UID %s: Changed in Cal --> Org" uid))
+           (cond (vevent (org-caldav-update-org-event))
+             (vtodo (org-caldav-update-org-todo))
+             (t (throw 'strange "Something strange has happend.")))
+           ))
+        ;; Update the event database.
+        (org-caldav-event-set-status cur 'synced)
+        (with-current-buffer buf
+          (org-caldav-event-set-md5
+           cur (md5 (buffer-substring-no-properties
+                     (org-entry-beginning-position)
+                     (org-entry-end-position))))))))
   ;; (Maybe) delete entries which were deleted in calendar.
   (unless (eq org-caldav-delete-org-entries 'never)
     (dolist (cur (org-caldav-filter-events 'deleted-in-cal))
       (org-id-goto (car cur))
       (when (or (eq org-caldav-delete-org-entries 'always)
-		(and (eq org-caldav-delete-org-entries 'ask)
-		     (y-or-n-p "Delete this entry? ")))
-	(delete-region (org-entry-beginning-position)
-		       (org-entry-end-position))
-	(setq org-caldav-event-list
-	      (delete cur org-caldav-event-list))
-	(org-caldav-debug-print 1
-	 (format "Event UID %s: Deleted from Org" (car cur)))
-	(push (list org-caldav-calendar-id (car cur)
-		    'deleted-in-cal 'removed-from-org)
-	      org-caldav-sync-result)))))
+                (and (eq org-caldav-delete-org-entries 'ask)
+                     (y-or-n-p "Delete this entry? ")))
+        (delete-region (org-entry-beginning-position)
+                       (org-entry-end-position))
+        (setq org-caldav-event-list
+              (delete cur org-caldav-event-list))
+        (org-caldav-debug-print 1
+         (format "Event UID %s: Deleted from Org" (car cur)))
+        (push (list org-caldav-calendar-id (car cur)
+                    'deleted-in-cal 'removed-from-org)
+              org-caldav-sync-result)))))
 
 (defun org-caldav-change-heading (newheading)
   "Change heading from Org item under point to NEWHEADING."
@@ -1079,18 +1230,18 @@ which can only be synced to calendar. Ignoring." uid))
   (goto-char (point-min))
   (org-show-subtree)
   (when (and (re-search-forward org-complex-heading-regexp nil t)
-	     (match-string 4))
+             (match-string 4))
     (let ((start (match-beginning 4))
-	  (end (match-end 4)))
+          (end (match-end 4)))
       ;; Check if a timestring is in the heading
       (goto-char start)
       (save-excursion
-	(when (re-search-forward org-maybe-keyword-time-regexp end t)
-	  ;; Check if timestring is at the beginning or end of heading
-	  (if (< (- end (match-end 0))
-		 (- (match-beginning 0) start))
-	      (setq end (1- (match-beginning 0)))
-	    (setq start (1+ (match-end 0))))))
+        (when (re-search-forward org-maybe-keyword-time-regexp end t)
+          ;; Check if timestring is at the beginning or end of heading
+          (if (< (- end (match-end 0))
+                 (- (match-beginning 0) start))
+              (setq end (1- (match-beginning 0)))
+            (setq start (1+ (match-end 0))))))
       (delete-region start end)
       (goto-char start)
       (insert newheading)))
@@ -1111,7 +1262,7 @@ is on s-expression."
 (defun org-caldav-backup-item ()
   "Put current item in backup file."
   (let ((item (buffer-substring (org-entry-beginning-position)
-				(org-entry-end-position))))
+                                (org-entry-end-position))))
     (with-current-buffer (find-file-noselect org-caldav-backup-file)
       (goto-char (point-max))
       (insert item "\n")
@@ -1122,50 +1273,92 @@ is on s-expression."
     (org-map-entries
      (lambda ()
        (let ((pt (apply 'org-agenda-skip-entry-if org-caldav-skip-conditions)))
-	 (when pt
-	   (delete-region (point) pt)))))))
+         (when pt
+           (delete-region (point) pt)))))))
+
+(defun org-caldav-timestamp-has-time-p (timestamp)
+  "Checks whether a timestamp has a time.
+Returns nil if not and (sec min hour) if it has."
+  (let ((ti (parse-time-string timestamp)))
+    (or (nth 0 ti) (nth 1 ti) (nth 2 ti))))
+
+(defun org-caldav-prepare-scheduled-deadline-timestamps (orgfiles)
+  "For nextcloud (or maybe the ical standard?) in vtodo the
+scheduled and deadline have all have a time specified or none of
+them.  So we find todo items which have deadline and scheduled
+specified, but one of them has and the other do not have any
+time, and we ask the user to fix that."
+  (org-map-entries
+    (lambda ()
+      (let ((sched (org-entry-get nil "SCHEDULED"))
+             (deadl (org-entry-get nil "DEADLINE"))
+             kchoice)
+        (when (and sched deadl)
+          (when (and (org-caldav-timestamp-has-time-p sched)
+                  (not (org-caldav-timestamp-has-time-p deadl)))
+            (org-id-goto (org-entry-get nil "ID"))
+            (setq kchoice (read-char-choice "Scheduled and Deadline
+            set.  For syncing you need to (s) set time on
+            DEADLINE, or (d) delete SCHEDULED time."
+                        '(?s ?d)))
+            (cond ((= kchoice ?s) (org-deadline nil))
+              ((= kchoice ?d) (org--deadline-or-schedule nil 'scheduled
+                                (replace-regexp-in-string " [0-2][0-9]:[0-5][0-9]" "" sched)))))
+          (when (and (not (org-caldav-timestamp-has-time-p sched))
+                  (org-caldav-timestamp-has-time-p deadl))
+            (org-id-goto (org-entry-get nil "ID"))
+            (setq kchoice (read-char-choice "Scheduled and Deadline
+            set.  For syncing you need to (s) set time on
+            SCHEDULED, or (d) delete DEADLINE time."
+                        '(?s ?d)))
+            (cond ((= kchoice ?s) (org-schedule nil))
+              ((= kchoice ?d) (org--deadline-or-schedule nil 'deadline
+                                (replace-regexp-in-string " [0-2][0-9]:[0-5][0-9]" "" sched))))))))
+    nil orgfiles))
 
 (defun org-caldav-generate-ics ()
   "Generate ICS file from `org-caldav-files'.
 Returns buffer containing the ICS file."
   (let ((icalendar-file
-	 (if (featurep 'ox-icalendar)
-	     'org-icalendar-combined-agenda-file
-	   'org-combined-agenda-icalendar-file))
-	(orgfiles (let ((inbox-file (org-caldav-inbox-file org-caldav-inbox)))
-		    (if (member inbox-file org-caldav-files)
-			org-caldav-files
-		      (append org-caldav-files
-			      (list inbox-file)))))
-	(org-export-select-tags org-caldav-select-tags)
-	(org-icalendar-exclude-tags org-caldav-exclude-tags)
-	;; We absolutely need UIDs for synchronization.
-	(org-icalendar-store-UID t)
-	;; Does not work yet
-	(org-icalendar-include-bbdb-anniversaries nil)
-	(icalendar-uid-format "orgsexp-%h")
-	(org-export-before-parsing-hook
-	 (append org-export-before-parsing-hook
-		 (when org-caldav-skip-conditions '(org-caldav-skip-function))))
-	(org-icalendar-date-time-format
-	 (cond
-	  ((and org-icalendar-timezone
-		(string= org-icalendar-timezone "UTC"))
-	   ":%Y%m%dT%H%M%SZ")
-	  (org-icalendar-timezone
-	   ";TZID=%Z:%Y%m%dT%H%M%S")
-	  (t
-	   ":%Y%m%dT%H%M%S"))))
+         (if (featurep 'ox-icalendar)
+             'org-icalendar-combined-agenda-file
+           'org-combined-agenda-icalendar-file))
+        (orgfiles (let ((inbox-file (org-caldav-inbox-file org-caldav-inbox)))
+                    (if (member inbox-file org-caldav-files)
+                        org-caldav-files
+                      (append org-caldav-files
+                              (list inbox-file)))))
+        (org-export-select-tags org-caldav-select-tags)
+        (org-icalendar-exclude-tags org-caldav-exclude-tags)
+        ;; We absolutely need UIDs for synchronization.
+        (org-icalendar-store-UID t)
+        ;; Does not work yet
+        (org-icalendar-include-bbdb-anniversaries nil)
+        (icalendar-uid-format "orgsexp-%h")
+        (org-export-before-parsing-hook
+         (append org-export-before-parsing-hook
+           (when org-caldav-skip-conditions '(org-caldav-skip-function))))
+         (org-icalendar-date-time-format
+         (cond
+          ((and org-icalendar-timezone
+                (string= org-icalendar-timezone "UTC"))
+           ":%Y%m%dT%H%M%SZ")
+          (org-icalendar-timezone
+           ";TZID=%Z:%Y%m%dT%H%M%S")
+          (t
+            ":%Y%m%dT%H%M%S"))))
+    ;; check scheduled and deadline for having both time or noone (vtodo)
+    (org-caldav-prepare-scheduled-deadline-timestamps orgfiles)
     (set icalendar-file (make-temp-file "org-caldav-"))
     (org-caldav-debug-print 1 (format "Generating ICS file %s."
-				      (symbol-value icalendar-file)))
+                                      (symbol-value icalendar-file)))
     ;; Export events to one single ICS file.
     (if (featurep 'ox-icalendar)
-	;; New exporter (Org 8)
-	;; Signature changed in version 8.3
-	(if (version< org-version "8.3beta")
-	    (apply 'org-icalendar--combine-files nil orgfiles)
-	  (apply 'org-icalendar--combine-files orgfiles))
+        ;; New exporter (Org 8)
+        ;; Signature changed in version 8.3
+        (if (version< org-version "8.3beta")
+            (apply 'org-icalendar--combine-files nil orgfiles)
+          (apply 'org-icalendar--combine-files orgfiles))
       (apply 'org-export-icalendar t orgfiles))
     (find-file-noselect (symbol-value icalendar-file))))
 
@@ -1174,14 +1367,14 @@ Returns buffer containing the ICS file."
   (if (re-search-forward "^UID:\\s-*\\(.+\\)\\s-*$" nil t)
       (let ((case-fold-search nil)
             (uid (match-string 1)))
-	(while (progn (forward-line)
-		      (looking-at " \\(.+\\)\\s-*$"))
-	  (setq uid (concat uid (match-string 1))))
-	(while (string-match "\\s-+" uid)
-	  (setq uid (replace-match "" nil nil uid)))
-	(when (string-match "^\\(\\(DL\\|SC\\|TS\\)[0-9]*-\\)" uid)
-	  (setq uid (replace-match "" nil nil uid)))
-	uid)
+        (while (progn (forward-line)
+                      (looking-at " \\(.+\\)\\s-*$"))
+          (setq uid (concat uid (match-string 1))))
+        (while (string-match "\\s-+" uid)
+          (setq uid (replace-match "" nil nil uid)))
+        (when (string-match "^\\(\\(DL\\|SC\\|TS\\|TODO\\)[0-9]*-\\)" uid)
+          (setq uid (replace-match "" nil nil uid)))
+        uid)
     (error "No UID could be found for current event.")))
 
 (defun org-caldav-narrow-next-event ()
@@ -1192,29 +1385,29 @@ Returns nil if there are no more events."
       (goto-char (point-min))
     (goto-char (point-max))
     (widen))
-  (if (null (search-forward "BEGIN:VEVENT" nil t))
+  (if (null (re-search-forward "BEGIN:V[EVENT|TODO]" nil t))
       (progn
-	;; No more events.
-	(widen)	nil)
+        ;; No more events.
+        (widen)	nil)
     (beginning-of-line)
     (narrow-to-region (point)
-		      (save-excursion
-			(search-forward "END:VEVENT")
-			(forward-line 1)
-			(point)))
+                      (save-excursion
+                        (re-search-forward "END:V[EVENT|TODO]")
+                        (forward-line 1)
+                        (point)))
     t))
 
 (defun org-caldav-narrow-event-under-point ()
   "Narrow ics event in the current buffer under point."
-  (unless (looking-at "BEGIN:VEVENT")
-    (when (null (search-backward "BEGIN:VEVENT" nil t))
+  (unless (or (looking-at "BEGIN:VEVENT") (looking-at "BEGIN:VTODO"))
+    (when (null (re-search-backward "BEGIN:V[EVENT|TODO]" nil t))
       (error "Cannot find event under point."))
     (beginning-of-line))
   (narrow-to-region (point)
-		    (save-excursion
-		      (search-forward "END:VEVENT")
-		      (forward-line 1)
-		      (point))))
+                    (save-excursion
+                      (re-search-forward "END:V[EVENT|TODO]")
+                      (forward-line 1)
+                      (point))))
 
 (defun org-caldav-rewrite-uid-in-event ()
   "Rewrite UID in current buffer.
@@ -1225,31 +1418,31 @@ is no UID to rewrite. Returns the UID."
     (goto-char (point-min))
     (let ((uid (org-caldav-get-uid)))
       (when uid
-	(goto-char (point-min))
-	(re-search-forward "^UID:")
-	(let ((pos (point)))
-	  (while (progn (forward-line)
-			(looking-at " \\(.+\\)\\s-*$")))
-	  (delete-region pos (point)))
-	(insert uid "\n"))
+        (goto-char (point-min))
+        (re-search-forward "^UID:")
+        (let ((pos (point)))
+          (while (progn (forward-line)
+                        (looking-at " \\(.+\\)\\s-*$")))
+          (delete-region pos (point)))
+        (insert uid "\n"))
       uid)))
 
 (defun org-caldav-debug-print (level &rest objects)
   "Print OBJECTS into debug buffer with debug level LEVEL.
 Do nothing if LEVEL is larger than `org-caldav-debug-level'."
   (unless (or (null org-caldav-debug-level)
-	      (> level org-caldav-debug-level))
+              (> level org-caldav-debug-level))
     (with-current-buffer (get-buffer-create org-caldav-debug-buffer)
       (dolist (cur objects)
-	(if (stringp cur)
-	    (insert cur)
-	  (prin1 cur (current-buffer)))
-	(insert "\n")))))
+        (if (stringp cur)
+            (insert cur)
+          (prin1 cur (current-buffer)))
+        (insert "\n")))))
 
 (defun org-caldav-buffer-narrowed-p ()
   "Return non-nil if current buffer is narrowed."
   (> (buffer-size) (- (point-max)
-		      (point-min))))
+                      (point-min))))
 
 (defun org-caldav-insert-org-entry (start-d start-t end-d end-t
                                             summary description
@@ -1273,56 +1466,225 @@ Returns MD5 from entry."
     (org-set-property "ID" (url-unhex-string uid)))
   (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
-	(org-entry-beginning-position)
-	(org-entry-end-position))))
+        (org-entry-beginning-position)
+        (org-entry-end-position))))
+
+;; copy from org-caldav-insert-org-entry, and adjusted to vtodo
+(defun org-caldav-insert-org-todo (start-d start-t due-d due-t
+                                    priority percent-complete
+                                    summary description
+                                    completed-d completed-t
+                                    categories
+                                    &optional uid level)
+  "Insert org block from given data at current position.
+START/DUE-D: Start/Due date.  START/DUE-T: Start/Due time.
+PRIORITY: 0-9, PERCENT-COMPLETE: 0-100.
+See `org-caldav-todo-priority' and
+`org-caldav-todo-percent-states' for explanations how this values
+are used.
+SUMMARY, DESCRIPTION, UID: obvious.
+Dates must be given in a format `org-read-date' can parse.
+
+If UID is nil, no UID: property is written.
+If LEVEL is nil, it defaults to 1.
+
+Returns MD5 from entry."
+  (let* ((nprio (string-to-number priority))
+          (r nil)
+          (vprio (dolist (p org-caldav-todo-priority r)
+                   (when (>= nprio (car p))
+                     (setq r (car (cdr p))))))
+          (prio (if vprio (concat "[#" vprio "] ") ""))
+          (npercent (string-to-number percent-complete))
+          (todostate (dolist (to org-caldav-todo-percent-states tstate)
+                       (when (>= npercent (car to))
+                         (setq tstate (car (cdr to)))))))
+    (insert (make-string (or level 1) ?*) " "
+      todostate " " prio
+      summary "\n"))
+  (when start-d
+    (org--deadline-or-schedule nil 'scheduled (org-caldav-convert-to-org-time start-d start-t)))
+  (when due-d
+    (org--deadline-or-schedule nil 'deadline (org-caldav-convert-to-org-time due-d due-t)))
+  (when completed-d
+    (org-add-planning-info 'closed (org-caldav-convert-to-org-time completed-d completed-t)))
+  (org-caldav-set-org-tags categories)
+  (when (> (length description) 0)
+    (insert "  " description "\n"))
+;;  (forward-line -1)
+  (when uid
+    (org-set-property "ID" (url-unhex-string uid)))
+ ;; (org-set-tags-to org-caldav-select-tags)
+  (md5 (buffer-substring-no-properties
+         (org-entry-beginning-position)
+         (org-entry-end-position))))
+
+(defun org-caldav-update-org-event ()
+  "Updates the org entry."
+  ;; no variables needed because this is only run in a specific context
+  (let ((marker (org-id-find (car cur) t)))
+    (when (null marker)
+      (error "Could not find UID %s." (car cur)))
+    (with-current-buffer (marker-buffer marker)
+      (goto-char (marker-position marker))
+      (when org-caldav-backup-file
+        (org-caldav-backup-item))
+      ;; See what we should sync.
+      (when (or (eq org-caldav-sync-changes-to-org 'title-only)
+              (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
+        ;; Sync title
+        (org-caldav-change-heading (nth 4 eventdata)))
+      (when (or (eq org-caldav-sync-changes-to-org 'timestamp-only)
+              (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
+        ;; Sync timestamp
+        (setq timesync
+          (org-caldav-change-timestamp
+            (apply 'org-caldav-create-time-range (butlast eventdata 2)))))
+      (when (eq org-caldav-sync-changes-to-org 'all)
+        ;; Sync everything, so first remove the old one.
+        (let ((level (org-current-level)))
+          (delete-region (org-entry-beginning-position)
+            (org-entry-end-position))
+          (apply 'org-caldav-insert-org-entry
+            (append eventdata (list uid level)))))
+      (setq buf (current-buffer))
+      (push (list org-caldav-calendar-id uid
+              (org-caldav-event-status cur)
+              (if (eq timesync 'orgsexp)
+                'error:changed-orgsexp 'cal->org))
+        org-caldav-sync-result))))
+
+(defun org-caldav-update-org-todo ()
+  "Updates the todo entry.
+Todo syncing is currently not configurable.  Create an issue on
+github if you need some configuration.
+
+This will update:  heading, priority, todo-state, scheduled, deadline.
+This will not update description (at the moment)."
+    ;; no variables needed because this is only run in a specific context
+  (let ((marker (org-id-find (car cur) t)))
+    (when (null marker)
+      (error "Could not find UID %s." (car cur)))
+    (with-current-buffer (marker-buffer marker)
+      (goto-char (marker-position marker))
+      (when org-caldav-backup-file
+        (org-caldav-backup-item))
+      ;; heading
+      (org-caldav-change-heading (nth 6 tododata))
+      ;; priority
+      (let* ((nprio (string-to-number (nth 4 tododata)))
+              (r nil)
+              (vprio (dolist (p org-caldav-todo-priority r)
+                   (when (>= nprio (car p))
+                     (setq r (car (cdr p)))))))
+        (when vprio
+          (org-priority (string-to-char vprio))))
+      ;; todo-state
+      (let* ((npercent (string-to-number (nth 5 tododata)))
+              (todostate (dolist (to org-caldav-todo-percent-states tstate)
+                       (when (>= npercent (car to))
+                         (setq tstate (car (cdr to)))))))
+        (org-todo todostate))
+      ;; scheduled, deadline
+      (when (nth 0 tododata)
+    (org--deadline-or-schedule nil 'scheduled
+      (org-caldav-convert-to-org-time (nth 0 tododata) (nth 1 tododata))))
+      (when (nth 2 tododata)
+        (org--deadline-or-schedule nil 'deadline (org-caldav-convert-to-org-time (nth 2 tododata) (nth 3 tododata))))
+      (when (nth 8 tododata)
+        (org-add-planning-info 'closed
+          (org-caldav-convert-to-org-time (nth 8 tododata) (nth 9 tododata))))
+      (org-caldav-set-org-tags (nth 10 tododata))
+      (setq buf (current-buffer))
+      (push (list org-caldav-calendar-id uid
+              (org-caldav-event-status cur)
+              (if (eq timesync 'orgsexp)
+                'error:changed-orgsexp 'cal->org))
+        org-caldav-sync-result))))
+
+(defun org-caldav-set-org-tags (tags)
+  "Set tags to the headline, where tags is a coma-seperated
+  string.  This comes from the ical CATEGORIES line."
+  (save-excursion
+    (org-back-to-heading)
+    (if (> (length tags) 0)
+      (let (cleantags)
+        (dolist (i (split-string tags ","))
+          (setq cleantags (cons
+                            (replace-regexp-in-string " " "-" (string-trim i))
+                            cleantags)))
+        (org-set-tags-to (reverse cleantags))
+        (org-set-tags t))
+      (org-set-tags-to nil))))
 
 (defun org-caldav-create-time-range (start-d start-t end-d end-t)
   "Creeate an Org timestamp range from START-D/T, END-D/T."
   (with-temp-buffer
     (org-caldav-insert-org-time-stamp start-d start-t)
     (if (and end-d
-	     (not (equal end-d start-d)))
-	(progn
-	  (insert "--")
-	  (org-caldav-insert-org-time-stamp end-d end-t))
+          (not (equal end-d start-d)))
+      (progn
+        (insert "--")
+        (org-caldav-insert-org-time-stamp end-d end-t))
       (when end-t
-	;; Same day, different time.
-	(backward-char 1)
-	(insert "-" end-t)))
+        ;; Same day, different time.
+        (backward-char 1)
+        (insert "-" end-t)))
     (buffer-string)))
 
 (defun org-caldav-insert-org-time-stamp (date &optional time)
   "Insert org time stamp using DATE and TIME at point.
 DATE is given as european date (DD MM YYYY)."
   (let* ((stime (when time (mapcar 'string-to-number
-				   (split-string time ":"))))
-	 (hours (if time (car stime) 0))
-	 (minutes (if time (nth 1 stime) 0))
-	 (sdate (mapcar 'string-to-number (split-string date)))
-	 (day (car sdate))
-	 (month (nth 1 sdate))
-	 (year (nth 2 sdate))
-	 (internaltime (encode-time 0 minutes hours day month year)))
+                             (split-string time ":"))))
+          (hours (if time (car stime) 0))
+          (minutes (if time (nth 1 stime) 0))
+          (sdate (mapcar 'string-to-number (split-string date)))
+          (day (car sdate))
+          (month (nth 1 sdate))
+          (year (nth 2 sdate))
+          (internaltime (encode-time 0 minutes hours day month year)))
     (insert
-     (concat "<"
-	     (if time
-		 (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
-	       (format-time-string "%Y-%m-%d %a" internaltime))
-	     ">"))))
+      (concat "<"
+        (if time
+          (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
+          (format-time-string "%Y-%m-%d %a" internaltime))
+        ">"))))
+
+
+;; is it needed?
+(defun org-caldav-convert-to-org-time (date &optional time)
+  "Returns an org "
+  "Insert org time stamp using DATE and TIME at point.
+DATE is given as european date (DD MM YYYY)."
+  (let* ((stime (when time (mapcar 'string-to-number
+                             (split-string time ":"))))
+          (hours (if time (car stime) 0))
+          (minutes (if time (nth 1 stime) 0))
+          (sdate (mapcar 'string-to-number (split-string date)))
+          (day (car sdate))
+          (month (nth 1 sdate))
+          (year (nth 2 sdate))
+          (internaltime (encode-time 0 minutes hours day month year)))
+    (concat
+      (if time
+        (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
+        (format-time-string "%Y-%m-%d %a" internaltime))
+      )))
 
 (defun org-caldav-save-sync-state ()
   "Save org-caldav sync database to disk.
 See also `org-caldav-save-directory'."
   (with-temp-buffer
     (insert ";; This is the sync state from org-caldav\n;; calendar-id: "
-	    org-caldav-calendar-id "\n;; Do not modify this file.\n\n")
+      org-caldav-calendar-id "\n;; Do not modify this file.\n\n")
     (insert "(setq org-caldav-event-list\n'")
     (let ((print-length nil)
-	  (print-level nil))
+           (print-level nil))
       (prin1 (delq nil
-		   (mapcar (lambda (ev) (unless (eq (org-caldav-event-status ev) 'error) ev))
-			   org-caldav-event-list))
-	     (current-buffer)))
+               (mapcar (lambda (ev) (unless (eq (org-caldav-event-status ev) 'error) ev))
+                 org-caldav-event-list))
+        (current-buffer)))
     (insert ")\n")
     ;; This is just cosmetics.
     (goto-char (point-min))
@@ -1330,24 +1692,24 @@ See also `org-caldav-save-directory'."
       (insert "\n"))
     ;; Save the current value of org-caldav-files
     (insert "(setq org-caldav-previous-files '"
-	    (prin1-to-string org-caldav-files) ")\n")
+      (prin1-to-string org-caldav-files) ")\n")
     ;; Save it.
     (write-region (point-min) (point-max)
-		  (org-caldav-sync-state-filename org-caldav-calendar-id))))
+      (org-caldav-sync-state-filename org-caldav-calendar-id))))
 
 (defun org-caldav-load-sync-state ()
   "Load org-caldav sync database from disk."
   (let ((filename (org-caldav-sync-state-filename org-caldav-calendar-id)))
     (when (file-exists-p filename)
       (with-temp-buffer
-	(insert-file-contents filename)
-	(eval-buffer)))))
+        (insert-file-contents filename)
+        (eval-buffer)))))
 
 (defun org-caldav-sync-state-filename (id)
   "Return filename for saving the sync state of calendar with ID."
   (expand-file-name
-   (concat "org-caldav-" (substring (md5 id) 1 8) ".el")
-   org-caldav-save-directory))
+    (concat "org-caldav-" (substring (md5 id) 1 8) ".el")
+    org-caldav-save-directory))
 
 (defvar org-caldav-sync-results-mode-map
   (let ((map (make-sparse-keymap)))
@@ -1363,15 +1725,15 @@ See also `org-caldav-save-directory'."
     (erase-buffer)
     (insert "CalDAV Sync finished.\n\n")
     (if (null org-caldav-sync-result)
-	(insert "Nothing was done.")
+      (insert "Nothing was done.")
       (insert "== Sync errors: \n\n")
       (org-caldav-sync-result-print-entries
-       (org-caldav-sync-result-filter-errors))
+        (org-caldav-sync-result-filter-errors))
       (insert "\n== Successful syncs: \n\n")
       (org-caldav-sync-result-print-entries
-       (org-caldav-sync-result-filter-errors t)))
+        (org-caldav-sync-result-filter-errors t)))
     (if (fboundp 'pop-to-buffer-same-window)
-	(pop-to-buffer-same-window (current-buffer))
+      (pop-to-buffer-same-window (current-buffer))
       (pop-to-buffer (current-buffer)))
     (setq buffer-read-only t)
     (goto-char (point-min))
@@ -1382,12 +1744,12 @@ See also `org-caldav-save-directory'."
   "Return items from sync results with errors.
 If COMPLEMENT is non-nil, return all item without errors."
   (delq nil
-	(mapcar
-	 (lambda (x)
-	   (if (string-match "^error" (symbol-name (car (last x))))
-	       (unless complement x)
-	     (when complement x)))
-	 org-caldav-sync-result)))
+        (mapcar
+         (lambda (x)
+           (if (string-match "^error" (symbol-name (car (last x))))
+               (unless complement x)
+             (when complement x)))
+         org-caldav-sync-result)))
 
 (defun org-caldav-sync-result-print-entries (entries)
   "Helper function to print ENTRIES."
@@ -1395,47 +1757,47 @@ If COMPLEMENT is non-nil, return all item without errors."
       (insert "None.\n")
     (dolist (entry entries)
       (let ((deleted (or (eq (nth 2 entry) 'deleted-in-org)
-			 (eq (nth 2 entry) 'deleted-in-cal))))
-	(insert "UID: ")
-	(let ((start (point)))
-	  (insert (nth 1 entry))
-	  (unless deleted
-	    (put-text-property start (point)
-			       'face 'link)))
-	(when (and (eq org-caldav-show-sync-results 'with-headings)
-		   (not deleted))
-	  (insert "\n   Title: "
-		  (or (org-caldav-get-heading-from-uid (nth 1 entry))
-		      "(no title)")))
-	(insert "\n   Status: "
-		(symbol-name (nth 2 entry))
-		"  Action: "
-		(symbol-name (nth 3 entry)))
-	(when org-caldav-calendars
-	  (insert "\n   Calendar: " (car entry)))
-	(insert "\n\n")))))
+                         (eq (nth 2 entry) 'deleted-in-cal))))
+        (insert "UID: ")
+        (let ((start (point)))
+          (insert (nth 1 entry))
+          (unless deleted
+            (put-text-property start (point)
+                               'face 'link)))
+        (when (and (eq org-caldav-show-sync-results 'with-headings)
+                   (not deleted))
+          (insert "\n   Title: "
+                  (or (org-caldav-get-heading-from-uid (nth 1 entry))
+                      "(no title)")))
+        (insert "\n   Status: "
+                (symbol-name (nth 2 entry))
+                "  Action: "
+                (symbol-name (nth 3 entry)))
+        (when org-caldav-calendars
+          (insert "\n   Calendar: " (car entry)))
+        (insert "\n\n")))))
 
 (defun org-caldav-get-heading-from-uid (uid)
   "Get org heading from entry with UID."
   (let ((marker (org-id-find uid t)))
     (if (null marker)
-	"(Could not find UID)"
+        "(Could not find UID)"
       (with-current-buffer (marker-buffer marker)
-	(goto-char (marker-position marker))
-	(org-narrow-to-subtree)
-	(goto-char (point-min))
-	(org-show-subtree)
-	(prog1
-	    (if (re-search-forward org-complex-heading-regexp nil t)
-		(match-string 4)
-	      "(Could not find heading)")
-	  (widen))))))
+        (goto-char (marker-position marker))
+        (org-narrow-to-subtree)
+        (goto-char (point-min))
+        (org-show-subtree)
+        (prog1
+            (if (re-search-forward org-complex-heading-regexp nil t)
+                (match-string 4)
+              "(Could not find heading)")
+          (widen))))))
 
 (defun org-caldav-goto-uid ()
   "Jump to UID unter point."
   (interactive)
   (when (equal (plist-get (text-properties-at (point)) 'face)
-	       'link)
+               'link)
     (beginning-of-line)
     (looking-at "UID: \\(.+\\)$")
     (org-id-goto (match-string 1))))
@@ -1443,12 +1805,12 @@ If COMPLEMENT is non-nil, return all item without errors."
 (defun org-caldav-get-calendar-summary-from-uid (uid)
   "Get summary from UID from calendar."
   (let ((buf (org-caldav-get-event uid))
-	(heading ""))
+        (heading ""))
     (when buf
       (with-current-buffer buf
-	(goto-char (point-min))
-	(when (re-search-forward "^SUMMARY:\\(.*\\)$" nil t)
-	  (setq heading (match-string 1)))))
+        (goto-char (point-min))
+        (when (re-search-forward "^SUMMARY:\\(.*\\)$" nil t)
+          (setq heading (match-string 1)))))
     heading))
 
 ;; The following is taken from icalendar.el, written by Ulf Jasper.
@@ -1464,110 +1826,205 @@ which can be fed into `org-caldav-insert-org-entry'."
     (insert decoded))
   (goto-char (point-min))
   (let* ((calendar-date-style 'european)
-	 (ical-list (icalendar--read-element nil nil))
-	 (e (car (icalendar--all-events ical-list)))
-	 (zone-map (icalendar--convert-all-timezones ical-list))
-	 (dtstart (icalendar--get-event-property e 'DTSTART))
-	 (dtstart-zone (icalendar--find-time-zone
-			(icalendar--get-event-property-attributes
-			 e 'DTSTART)
-			zone-map))
-	 (dtstart-dec (icalendar--decode-isodatetime dtstart nil
-						     dtstart-zone))
-	 (start-d (icalendar--datetime-to-diary-date
-		   dtstart-dec))
-	 (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
-	 (dtend (icalendar--get-event-property e 'DTEND))
-	 (dtend-zone (icalendar--find-time-zone
-		      (icalendar--get-event-property-attributes
-		       e 'DTEND)
-		      zone-map))
-	 (dtend-dec (icalendar--decode-isodatetime dtend
-						   nil dtend-zone))
-	 (dtend-1-dec (icalendar--decode-isodatetime dtend -1
-						     dtend-zone))
-	 end-d
-	 end-1-d
-	 end-t
-	 (summary (icalendar--convert-string-for-import
-		   (or (icalendar--get-event-property e 'SUMMARY)
-		       "No Title")))
-	 (description (icalendar--convert-string-for-import
-		       (or (icalendar--get-event-property e 'DESCRIPTION)
-			   "")))
-	 (rrule (icalendar--get-event-property e 'RRULE))
-	 (rdate (icalendar--get-event-property e 'RDATE))
-	 (duration (icalendar--get-event-property e 'DURATION)))
+         (ical-list (icalendar--read-element nil nil))
+         (e (car (icalendar--all-events ical-list)))
+         (zone-map (icalendar--convert-all-timezones ical-list))
+         (dtstart (icalendar--get-event-property e 'DTSTART))
+         (dtstart-zone (icalendar--find-time-zone
+                        (icalendar--get-event-property-attributes
+                         e 'DTSTART)
+                        zone-map))
+         (dtstart-dec (icalendar--decode-isodatetime dtstart nil
+                                                     dtstart-zone))
+         (start-d (icalendar--datetime-to-diary-date
+                   dtstart-dec))
+         (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
+         (dtend (icalendar--get-event-property e 'DTEND))
+         (dtend-zone (icalendar--find-time-zone
+                      (icalendar--get-event-property-attributes
+                       e 'DTEND)
+                      zone-map))
+         (dtend-dec (icalendar--decode-isodatetime dtend
+                                                   nil dtend-zone))
+         (dtend-1-dec (icalendar--decode-isodatetime dtend -1
+                                                     dtend-zone))
+         end-d
+         end-1-d
+         end-t
+         (summary (icalendar--convert-string-for-import
+                   (or (icalendar--get-event-property e 'SUMMARY)
+                       "No Title")))
+         (description (icalendar--convert-string-for-import
+                       (or (icalendar--get-event-property e 'DESCRIPTION)
+                           "")))
+         (rrule (icalendar--get-event-property e 'RRULE))
+         (rdate (icalendar--get-event-property e 'RDATE))
+         (duration (icalendar--get-event-property e 'DURATION)))
     ;; check whether start-time is missing
     (if	(and dtstart
-	     (string=
-	      (cadr (icalendar--get-event-property-attributes
-		     e 'DTSTART))
-	      "DATE"))
-	(setq start-t nil))
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'DTSTART))
+              "DATE"))
+        (setq start-t nil))
     (when duration
       (let ((dtend-dec-d (icalendar--add-decoded-times
-			  dtstart-dec
-			  (icalendar--decode-isoduration duration)))
-	    (dtend-1-dec-d (icalendar--add-decoded-times
-			    dtstart-dec
-			    (icalendar--decode-isoduration duration
-							   t))))
-	(if (and dtend-dec (not (eq dtend-dec dtend-dec-d)))
-	    (message "Inconsistent endtime and duration for %s"
-		     summary))
-	(setq dtend-dec dtend-dec-d)
-	(setq dtend-1-dec dtend-1-dec-d)))
+                          dtstart-dec
+                          (icalendar--decode-isoduration duration)))
+            (dtend-1-dec-d (icalendar--add-decoded-times
+                            dtstart-dec
+                            (icalendar--decode-isoduration duration
+                                                           t))))
+        (if (and dtend-dec (not (eq dtend-dec dtend-dec-d)))
+            (message "Inconsistent endtime and duration for %s"
+                     summary))
+        (setq dtend-dec dtend-dec-d)
+        (setq dtend-1-dec dtend-1-dec-d)))
     (setq end-d (if dtend-dec
-		    (icalendar--datetime-to-diary-date dtend-dec)
-		  start-d))
+                    (icalendar--datetime-to-diary-date dtend-dec)
+                  start-d))
     (setq end-1-d (if dtend-1-dec
-		      (icalendar--datetime-to-diary-date dtend-1-dec)
-		    start-d))
+                      (icalendar--datetime-to-diary-date dtend-1-dec)
+                    start-d))
     (setq end-t (if (and
-		     dtend-dec
-		     (not (string=
-			   (cadr
-			    (icalendar--get-event-property-attributes
-			     e 'DTEND))
-			   "DATE")))
-		    (icalendar--datetime-to-colontime dtend-dec)
-		  start-t))
+                     dtend-dec
+                     (not (string=
+                           (cadr
+                            (icalendar--get-event-property-attributes
+                             e 'DTEND))
+                           "DATE")))
+                    (icalendar--datetime-to-colontime dtend-dec)
+                  start-t))
     ;; Return result
     (list start-d start-t
-	  (if end-t end-d end-1-d)
-	  end-t summary description)))
+          (if end-t end-d end-1-d)
+          end-t summary description)))
+
+(defun org-caldav--icalendar--all-todos (icalendar)
+  "Return the list of all existing todos in the given ICALENDAR."
+  (let ((result '()))
+    (mapc (lambda (elt)
+            (setq result (append (icalendar--get-children elt 'VTODO)
+                                 result)))
+          (nreverse icalendar))
+    result))
+
+
+;; I simple copied that from org-caldav-convert-event and made adjustments
+(defun org-caldav-convert-todo ()
+  "Convert icalendar todo in current buffer.
+Returns a list '(start-d start-t due-d due-t priority percent-complete summary description
+completed-d completed-t categories)'
+which can be fed into `org-caldav-insert-org-todo'."
+  (let ((decoded (decode-coding-region (point-min) (point-max) 'utf-8 t)))
+    (erase-buffer)
+    (set-buffer-multibyte t)
+    (setq buffer-file-coding-system 'utf-8)
+    (insert decoded))
+  (goto-char (point-min))
+  (let* ((calendar-date-style 'european)
+         (ical-list (icalendar--read-element nil nil))
+         (e (car (org-caldav--icalendar--all-todos ical-list)))
+         (zone-map (icalendar--convert-all-timezones ical-list))
+         (dtstart (icalendar--get-event-property e 'DTSTART))
+         (dtstart-zone (icalendar--find-time-zone
+                        (icalendar--get-event-property-attributes
+                         e 'DTSTART)
+                        zone-map))
+         (dtstart-dec (icalendar--decode-isodatetime dtstart nil
+                                                     dtstart-zone))
+         (start-d (icalendar--datetime-to-diary-date
+                   dtstart-dec))
+         (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
+         (dtdue (icalendar--get-event-property e 'DUE))
+         (dtdue-zone (icalendar--find-time-zone
+                      (icalendar--get-event-property-attributes
+                       e 'DUE)
+                      zone-map))
+         (dtdue-dec (icalendar--decode-isodatetime dtdue
+                                                   nil dtdue-zone))
+          (due-d (icalendar--datetime-to-diary-date
+                  dtdue-dec))
+         (due-t (if dtdue-dec (icalendar--datetime-to-colontime dtdue-dec) nil))
+         (dtcompleted (icalendar--get-event-property e 'COMPLETED))
+         (dtcompleted-zone (icalendar--find-time-zone
+                      (icalendar--get-event-property-attributes
+                       e 'COMPLETED)
+                      zone-map))
+         (dtcompleted-dec (icalendar--decode-isodatetime dtcompleted
+                                                   nil dtcompleted-zone))
+          (completed-d (icalendar--datetime-to-diary-date
+                  dtcompleted-dec))
+         (completed-t (if dtcompleted-dec (icalendar--datetime-to-colontime dtcompleted-dec) nil))
+         (summary (icalendar--convert-string-for-import
+                   (or (icalendar--get-event-property e 'SUMMARY)
+                       "No Title")))
+         (description (icalendar--convert-string-for-import
+                       (or (icalendar--get-event-property e 'DESCRIPTION)
+                         "")))
+          (categories (icalendar--convert-string-for-import
+                        (or (icalendar--get-event-property e 'CATEGORIES)
+                          "")))
+          (priority (icalendar--get-event-property e 'PRIORITY))
+          (percent-complete (icalendar--get-event-property e 'PERCENT-COMPLETE)))
+    ;; check wether start-time is missing
+    (if	(and dtstart
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'DTSTART))
+              "DATE"))
+        (setq start-t nil))
+    ;; same for due-time
+    (if	(and dtdue
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'DUE))
+              "DATE"))
+        (setq due-t nil))
+    ;; and completed
+    (if	(and dtcompleted
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'COMPLETED))
+              "DATE"))
+        (setq completed-t nil))
+    (list start-d start-t
+      due-d due-t
+      priority percent-complete
+      summary description
+      completed-d completed-t
+      categories)))
+
 
 ;; This is adapted from url-dav.el, written by Bill Perry.
 ;; This does more error checking on the headers and retries
 ;; in case of an error.
 (defun org-caldav-save-resource (url obj)
   "Save string OBJ as URL using WebDAV.
-This witches to OAuth2 if necessary."
+This switches to OAuth2 if necessary."
   (let* ((counter 0)
-	 errormessage buffer)
+         errormessage buffer)
     (while (and (not buffer)
-		(< counter org-caldav-retry-attempts))
+                (< counter org-caldav-retry-attempts))
       (with-current-buffer
-	  (org-caldav-url-retrieve-synchronously
-	   url "PUT" obj
-	   '(("Content-type" . "text/calendar; charset=UTF-8")))
-	(goto-char (point-min))
-	(if (looking-at "HTTP.*2[0-9][0-9]")
-	    (setq buffer (current-buffer))
-	  ;; There was an error putting the resource, try again.
-    	  (setq errormessage (buffer-substring (point-min) (point-at-eol)))
-	  (setq counter (1+ counter))
-	  (org-caldav-debug-print
-	   1 (format "(Try %d) Error when trying to put URL %s: %s"
-		     counter url errormessage))
-	  (kill-buffer))))
+          (org-caldav-url-retrieve-synchronously
+           url "PUT" obj
+           '(("Content-type" . "text/calendar; charset=UTF-8")))
+        (goto-char (point-min))
+        (if (looking-at "HTTP.*2[0-9][0-9]")
+            (setq buffer (current-buffer))
+          ;; There was an error putting the resource, try again.
+          (setq errormessage (buffer-substring (point-min) (point-at-eol)))
+          (setq counter (1+ counter))
+          (org-caldav-debug-print 1
+            (format "(Try %d) Error when trying to put URL %s: %s"
+              counter url errormessage))
+          (kill-buffer))))
     (if buffer
-	(kill-buffer buffer)
-      (org-caldav-debug-print
-       1
-       "Failed to put URL %s after %d tries with error %s"
-       url org-caldav-retry-attempts errormessage))
+        (kill-buffer buffer)
+      (org-caldav-debug-print 1
+        (format "Failed to put URL %s after %d tries with error %s"
+          url org-caldav-retry-attempts errormessage)))
     (< counter org-caldav-retry-attempts)))
 
 ;;;###autoload

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1282,7 +1282,7 @@ is on s-expression."
      (lambda ()
        (let ((pt (apply 'org-agenda-skip-entry-if org-caldav-skip-conditions))
               (ts (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
-              (stamp (org-entry-get nil "TIMESTAMP" t)))
+              (stamp (or (org-entry-get nil "TIMESTAMP" t) (org-entry-get nil "CLOSED" t))))
 	 (when (or pt (and stamp (> ts (org-time-stamp-to-now stamp))))
 	   (delete-region (point) (or pt (org-end-of-subtree t)))))))))
 

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1289,7 +1289,8 @@ is on s-expression."
   (goto-char (point-min))
   (if (search-forward "<%%(" nil t)
       'orgsexp
-    (when (re-search-forward org-maybe-keyword-time-regexp nil t)
+    (when (or (re-search-forward org-tr-regexp nil t)
+              (re-search-forward org-maybe-keyword-time-regexp nil t))
       (replace-match newtime nil t))
     (widen)))
 

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -989,9 +989,12 @@ The ics must be in the current buffer."
       (when seq
         (setq seq (1+ seq))
         (goto-char (point-min))
-        (unless (re-search-forward "^SEQUENCE:" nil t)
-          (org-caldav-debug-print 2 (format "UID %s: SEQUENCE not in Buffer %s" (car event) (buffer-name))))
-        (delete-region (point-at-bol) (+ 1 (point-at-eol)))
+        (if (re-search-forward "^SEQUENCE:" nil t)
+          (delete-region (point-at-bol) (+ 1 (point-at-eol)))
+          (progn
+            (org-caldav-debug-print 2 (format "UID %s: SEQUENCE not in Buffer %s" (car event) (buffer-name)))
+            (re-search-forward "^BEGIN:")
+            (next-line)))
         (beginning-of-line)
         (insert "SEQUENCE:" (number-to-string seq) "\n")
         (org-caldav-event-set-sequence event seq)))))

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1330,7 +1330,7 @@ time, and we ask the user to fix that."
         (when (and sched deadl)
           (when (and (org-caldav-timestamp-has-time-p sched)
                   (not (org-caldav-timestamp-has-time-p deadl)))
-            (org-id-goto (org-entry-get nil "ID"))
+            (org-id-goto (org-id-get-create))
             (setq kchoice (read-char-choice "Scheduled and Deadline
             set.  For syncing you need to (s) set time on
             DEADLINE, or (d) delete SCHEDULED time."

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -1281,6 +1281,14 @@ which can only be synced to calendar. Ignoring." uid))
       (insert newheading)))
   (widen))
 
+(defun org-caldav-change-location (newlocation)
+  "Change the LOCATION property from ORG item under point to
+NEWLOCATION. If newlocation is \"\", removes the location
+property."
+  (if (> (length newlocation) 0)
+      (org-set-property "LOCATION" newlocation)
+    (org-delete-property "LOCATION")))
+
 (defun org-caldav-change-timestamp (newtime)
   "Change timestamp from Org item under point to NEWTIME.
 Return symbol 'orgsexp if this entry cannot be changed because it
@@ -1487,25 +1495,29 @@ Do nothing if LEVEL is larger than `org-caldav-debug-level'."
                       (point-min))))
 
 (defun org-caldav-insert-org-entry (start-d start-t end-d end-t
-                                            summary description
+                                            summary description location
                                             &optional uid level)
   "Insert org block from given data at current position.
 START/END-D: Start/End date.  START/END-T: Start/End time.
-SUMMARY, DESCRIPTION, UID: obvious.
+SUMMARY, DESCRIPTION, LOCATION, UID: obvious.
 Dates must be given in a format `org-read-date' can parse.
 
+If LOCATION is \"\", no LOCATION: property is written.
 If UID is nil, no UID: property is written.
 If LEVEL is nil, it defaults to 1.
 
 Returns MD5 from entry."
   (insert (make-string (or level 1) ?*) " " summary "\n")
-  (insert "  "
+  (insert (if org-adapt-indentation "  " "")
    (org-caldav-create-time-range start-d start-t end-d end-t) "\n")
   (when (> (length description) 0)
     (insert "  " description "\n"))
   (forward-line -1)
   (when uid
     (org-set-property "ID" (url-unhex-string uid)))
+  (if (> (length location) 0)
+      (org-set-property "LOCATION" location)
+    (org-delete-property "LOCATION"))
   (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
         (org-entry-beginning-position)
@@ -1575,13 +1587,15 @@ Returns MD5 from entry."
       (when (or (eq org-caldav-sync-changes-to-org 'title-only)
               (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
         ;; Sync title
-        (org-caldav-change-heading (nth 4 eventdata)))
+    (org-caldav-change-heading (nth 4 eventdata))
+    ;; and location
+    (org-caldav-change-location (nth 6 eventdata)))
       (when (or (eq org-caldav-sync-changes-to-org 'timestamp-only)
               (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
         ;; Sync timestamp
         (setq timesync
           (org-caldav-change-timestamp
-            (apply 'org-caldav-create-time-range (butlast eventdata 2)))))
+           (apply 'org-caldav-create-time-range (butlast eventdata 3)))))
       (when (eq org-caldav-sync-changes-to-org 'all)
         ;; Sync everything, so first remove the old one.
         (let ((level (org-current-level)))
@@ -1885,10 +1899,10 @@ If COMPLEMENT is non-nil, return all item without errors."
     heading))
 
 ;; The following is taken from icalendar.el, written by Ulf Jasper.
-
+;; The LOCATION property is added the extracted list
 (defun org-caldav-convert-event ()
   "Convert icalendar event in current buffer.
-Returns a list '(start-d start-t end-d end-t summary description)'
+Returns a list '(start-d start-t end-d end-t summary description location)'
 which can be fed into `org-caldav-insert-org-entry'."
   (let ((decoded (decode-coding-region (point-min) (point-max) 'utf-8 t)))
     (erase-buffer)
@@ -1928,6 +1942,9 @@ which can be fed into `org-caldav-insert-org-entry'."
           (description (icalendar--convert-string-for-import
                          (or (icalendar--get-event-property e 'DESCRIPTION)
                            "")))
+   (location (icalendar--convert-string-for-import
+                    (or (icalendar--get-event-property e 'LOCATION)
+                        "")))
           (rrule (icalendar--get-event-property e 'RRULE))
           (rdate (icalendar--get-event-property e 'RDATE))
           (duration (icalendar--get-event-property e 'DURATION)))
@@ -1969,7 +1986,7 @@ which can be fed into `org-caldav-insert-org-entry'."
     ;; Return result
     (list start-d start-t
       (if end-t end-d end-1-d)
-      end-t summary description)))
+    end-t summary description location)))
 
 (defun org-caldav--icalendar--all-todos (icalendar)
   "Return the list of all existing todos in the given ICALENDAR."

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -254,9 +254,9 @@ always = Always resume")
 
 (defvar org-caldav-oauth2-providers
   '((google "https://accounts.google.com/o/oauth2/auth"
-           "https://accounts.google.com/o/oauth2/token"
-           "https://www.googleapis.com/auth/calendar"
-           "https://apidata.googleusercontent.com/caldav/v2/%s/events"))
+            "https://accounts.google.com/o/oauth2/token"
+            "https://www.googleapis.com/auth/calendar"
+            "https://apidata.googleusercontent.com/caldav/v2/%s/events"))
   "List of providers that need OAuth2.  Each must be of the form
 
     IDENTIFIER AUTH-URL TOKEN-URL RESOURCE-URL CALENDAR-URL
@@ -425,9 +425,9 @@ configured correctly, and throw an user error otherwise."
         token))))
 
 (defun org-caldav-url-retrieve-synchronously (url &optional
-                                              request-method
-                                              request-data
-                                              extra-headers)
+                                                  request-method
+                                                  request-data
+                                                  extra-headers)
   "Retrieve URL with REQUEST-METHOD, REQUEST-DATA and EXTRA-HEADERS.
 This will switch to OAuth2 if necessary."
   (if (org-caldav-use-oauth2)
@@ -463,12 +463,12 @@ OAuth2 if necessary."
                               "<DAV:" property "/></DAV:prop></DAV:propfind>\n"))
         (extra '(("Depth" . "1") ("Content-type" . "text/xml"))))
     (let ((resultbuf (org-caldav-url-retrieve-synchronously
-                       url "PROPFIND" request-data extra))
-           (retr 1))
+                      url "PROPFIND" request-data extra))
+          (retr 1))
       (while (and (= 0 (buffer-size resultbuf)) (< retr org-caldav-retry-attempts))
         (org-caldav-debug-print 1 (format "org-caldav-url-dav-get-properties: could not get data from url: %s\n trying again..." url))
         (setq resultbuf (org-caldav-url-retrieve-synchronously
-                          url "PROPFIND" request-data extra))
+                         url "PROPFIND" request-data extra))
         (setq retr (1+ retr)))
       (org-caldav-namespace-bug-workaround resultbuf)
       (url-dav-process-response resultbuf url))))
@@ -506,13 +506,13 @@ Also sets `org-caldav-empty-calendar' if calendar is empty."
     (while (setq prop (pop properties))
       (let ((url (car prop))
             (etag (plist-get (cdr prop) 'DAV:getetag)))
-      (if (string-match (concat ".*/\\(.+\\)\\" org-caldav-uuid-extension "/?$") url)
-          (setq url (match-string 1 url))
-        (setq url nil))
-      (when (string-match "\"\\(.*\\)\"" etag)
-        (setq etag (match-string 1 etag)))
-      (when (and url etag)
-        (push (cons (url-unhex-string url) etag) files))))
+        (if (string-match (concat ".*/\\(.+\\)\\" org-caldav-uuid-extension "/?$") url)
+            (setq url (match-string 1 url))
+          (setq url nil))
+        (when (string-match "\"\\(.*\\)\"" etag)
+          (setq etag (match-string 1 etag)))
+        (when (and url etag)
+          (push (cons (url-unhex-string url) etag) files))))
     files))
 
 (defun org-caldav-get-event-etag-list ()
@@ -692,23 +692,23 @@ Are you really sure? ")))
          ((null event)
           ;; Event does not yet exist in DB, so add it.
           (org-caldav-debug-print 1
-           (format "Org UID %s: New" uid))
+                                  (format "Org UID %s: New" uid))
           (org-caldav-add-event uid md5 nil nil 'new-in-org))
          ((not (string= md5 (org-caldav-event-md5 event)))
           ;; Event exists but has changed MD5, so mark it as changed.
           (org-caldav-debug-print 1
-           (format "Org UID %s: Changed" uid))
+                                  (format "Org UID %s: Changed" uid))
           (org-caldav-event-set-md5 event md5)
           (org-caldav-event-set-status event 'changed-in-org))
          ((eq (org-caldav-event-status event) 'new-in-org)
           (org-caldav-debug-print 1
-           (format "Org UID %s: Error. Double entry." uid))
+                                  (format "Org UID %s: Error. Double entry." uid))
           (push (list org-caldav-calendar-id
                       uid 'new-in-org 'error:double-entry)
                 org-caldav-sync-result))
          (t
           (org-caldav-debug-print 1
-           (format "Org UID %s: Synced" uid))
+                                  (format "Org UID %s: Synced" uid))
           (org-caldav-event-set-status event 'in-org)))))
     ;; Mark events deleted in Org
     (dolist (cur (org-caldav-filter-events nil))
@@ -728,30 +728,30 @@ Are you really sure? ")))
        ((not dbentry)
         ;; Event is not yet in database, so add it.
         (org-caldav-debug-print 1
-         (format "Cal UID %s: New" (car cur)))
+                                (format "Cal UID %s: New" (car cur)))
         (org-caldav-add-event (car cur) nil (cdr cur) nil 'new-in-cal))
        ((or (eq (org-caldav-event-status dbentry) 'changed-in-org)
             (eq (org-caldav-event-status dbentry) 'deleted-in-org))
         (org-caldav-debug-print 1
-         (format "Cal UID %s: Ignoring (Org always wins)." (car cur))))
+                                (format "Cal UID %s: Ignoring (Org always wins)." (car cur))))
        ((null (org-caldav-event-etag dbentry))
         (org-caldav-debug-print 1
-         (format "Cal UID %s: No Etag. Mark as change, so putting it again." (car cur)))
+                                (format "Cal UID %s: No Etag. Mark as change, so putting it again." (car cur)))
         (org-caldav-event-set-status dbentry 'changed-in-org))
        ((not (string= (cdr cur) (org-caldav-event-etag dbentry)))
         ;; Event's etag changed.
         (org-caldav-debug-print 1
-         (format "Cal UID %s: Changed" (car cur)))
+                                (format "Cal UID %s: Changed" (car cur)))
         (org-caldav-event-set-status dbentry 'changed-in-cal)
         (org-caldav-event-set-etag dbentry (cdr cur)))
        ((null (org-caldav-event-status dbentry))
         ;; Event was deleted in Org
         (org-caldav-debug-print 1
-         (format "Cal UID %s: Deleted in Org" (car cur)))
+                                (format "Cal UID %s: Deleted in Org" (car cur)))
         (org-caldav-event-set-status dbentry 'deleted-in-org))
        ((eq (org-caldav-event-status dbentry) 'in-org)
         (org-caldav-debug-print 1
-         (format "Cal UID %s: Synced" (car cur)))
+                                (format "Cal UID %s: Synced" (car cur)))
         (org-caldav-event-set-status dbentry 'synced))
        ((eq (org-caldav-event-status dbentry) 'changed-in-org)
         ;; Do nothing
@@ -761,7 +761,7 @@ Are you really sure? ")))
     ;; Mark events deleted in cal.
     (dolist (cur (org-caldav-filter-events 'in-org))
       (org-caldav-debug-print 1
-       (format "Cal UID %s: Deleted in Cal" (car cur)))
+                              (format "Cal UID %s: Deleted in Cal" (car cur)))
       (org-caldav-event-set-status cur 'deleted-in-cal))))
 
 (defun org-caldav-generate-md5-for-org-entry (uid)
@@ -900,9 +900,9 @@ ICSBUF is the buffer containing the exported iCalendar file."
         (setq counter (1+ counter))
         (if (eq (org-caldav-event-etag cur) 'put)
             (org-caldav-debug-print 1
-             (format "Event UID %s: Was already put previously." (car cur)))
+                                    (format "Event UID %s: Was already put previously." (car cur)))
           (org-caldav-debug-print 1
-           (format "Event UID %s: Org --> Cal" (car cur)))
+                                  (format "Event UID %s: Org --> Cal" (car cur)))
           (widen)
           (goto-char (point-min))
           (while (and (setq uid (org-caldav-get-uid))
@@ -922,7 +922,7 @@ ICSBUF is the buffer containing the exported iCalendar file."
           (if (org-caldav-put-event icsbuf)
               (org-caldav-event-set-etag cur 'put)
             (org-caldav-debug-print 1
-             (format "Event UID %s: Error while doing Org --> Cal" (car cur)))
+                                    (format "Event UID %s: Error while doing Org --> Cal" (car cur)))
             (org-caldav-event-set-status cur 'error)
             (push (list org-caldav-calendar-id (car cur)
                         'error 'error:org->cal)
@@ -946,8 +946,8 @@ ICSBUF is the buffer containing the exported iCalendar file."
           (setq counter (1+ counter))
           (when (or (eq org-caldav-delete-calendar-entries 'always)
                     (y-or-n-p (format "Delete event '%s' from calendar?"
-                                       (org-caldav-get-calendar-summary-from-uid
-                                        (car cur)))))
+                                      (org-caldav-get-calendar-summary-from-uid
+                                       (car cur)))))
             (message "Deleting event %d from %d" counter (length events))
             (org-caldav-delete-event (car cur))
             (push (list org-caldav-calendar-id (car cur)
@@ -1024,15 +1024,15 @@ This is a bug in older Org versions."
       (unless (eq (thing-at-point 'number) 0)
         (delete-region (point) (- (point-at-eol) 1))
         (insert (number-to-string
-                  (save-excursion
-                    (goto-char (point-min))
-                    (org-id-goto (org-caldav-get-uid))
-                    (if (re-search-forward org-priority-regexp nil t)
-                      (let ((prio (org-entry-get nil "PRIORITY")))
-                        (dolist (pri org-caldav-todo-priority r)
-                          (when (string= (car (cdr pri)) prio)
-                            (setq r (car pri)))))
-                      0))))))))
+                 (save-excursion
+                   (goto-char (point-min))
+                   (org-id-goto (org-caldav-get-uid))
+                   (if (re-search-forward org-priority-regexp nil t)
+                       (let ((prio (org-entry-get nil "PRIORITY")))
+                         (dolist (pri org-caldav-todo-priority r)
+                           (when (string= (car (cdr pri)) prio)
+                             (setq r (car pri)))))
+                     0))))))))
 
 (defun org-caldav-fix-todo-status-percent-state ()
   "icalendar exports only sets the STATUS but not the
@@ -1045,25 +1045,25 @@ TODO: save percent-complete also as a property in org"
     (goto-char (point-min))
     (when (search-forward "BEGIN:VTODO" nil t)
       (if (search-forward "STATUS:" nil t)
-        (delete-region (point-at-bol) (+ 1 (point-at-eol)))
+          (delete-region (point-at-bol) (+ 1 (point-at-eol)))
         (progn (search-forward "END:VTODO")
-          (goto-char (point-at-bol))))
+               (goto-char (point-at-bol))))
 
 
       (let* ((state (save-excursion
                       (goto-char (point-min))
                       (org-id-goto (org-caldav-get-uid))
                       (substring-no-properties (org-get-todo-state))))
-              (percent (dolist (p org-caldav-todo-percent-states r)
-                         (when (string= state (car (cdr p)))
-                           (setq r (car p)))))
-              (status (cond ((= percent 0) "NEEDS-ACTION")
-                        ((= percent 100) "COMPLETED")
-                        (t "IN-PROCESS")))
-              (completed (save-excursion
-                           (goto-char (point-min))
-                           (org-id-goto (org-caldav-get-uid))
-                           (org-element-property :closed (org-element-at-point)))))
+             (percent (dolist (p org-caldav-todo-percent-states r)
+                        (when (string= state (car (cdr p)))
+                          (setq r (car p)))))
+             (status (cond ((= percent 0) "NEEDS-ACTION")
+                           ((= percent 100) "COMPLETED")
+                           (t "IN-PROCESS")))
+             (completed (save-excursion
+                          (goto-char (point-min))
+                          (org-id-goto (org-caldav-get-uid))
+                          (org-element-property :closed (org-element-at-point)))))
         (insert "PERCENT-COMPLETE:" (number-to-string percent) "\n")
         (insert "STATUS:" status "\n")
         ;; if closed missing but in DONE state:
@@ -1076,7 +1076,7 @@ TODO: save percent-complete also as a property in org"
           )
         (when completed
           (insert (org-icalendar-convert-timestamp
-                    completed "COMPLETED") "\n"))))))
+                   completed "COMPLETED") "\n"))))))
 
 
 (defun org-caldav-fix-categories ()
@@ -1085,7 +1085,7 @@ TODO: save percent-complete also as a property in org"
   (save-excursion
     (goto-char (point-min))
     (when (and (search-forward "CATEGORIES:" nil t)
-            (not (thing-at-point 'word)))
+               (not (thing-at-point 'word)))
       (delete-region (point-at-bol) (+ (point-at-eol) 1)))))
 
 (defun org-caldav-fix-todo-dtstart ()
@@ -1101,14 +1101,14 @@ also look if there is a deadline."
     (goto-char (point-min))
     (when (search-forward "BEGIN:VTODO" nil t)
       (when
-        (search-forward "DTSTART" nil t)
+          (search-forward "DTSTART" nil t)
         (unless
-          (save-excursion
-            (goto-char (point-min))
-            (org-id-goto (org-caldav-get-uid))
-            (if org-caldav-todo-deadline-schedule-warning-days
-              (or (org-get-scheduled-time nil) (org-get-deadline-time nil))
-              (org-get-scheduled-time nil)))
+            (save-excursion
+              (goto-char (point-min))
+              (org-id-goto (org-caldav-get-uid))
+              (if org-caldav-todo-deadline-schedule-warning-days
+                  (or (org-get-scheduled-time nil) (org-get-deadline-time nil))
+                (org-get-scheduled-time nil)))
           (delete-region (point-at-bol) (+ 1 (point-at-eol))))))))
 
 (defun org-caldav-inbox-file (inbox)
@@ -1201,10 +1201,10 @@ returned as a cons (POINT . LEVEL)."
                   (goto-char (car point-and-level))
                   (when vevent
                     (apply 'org-caldav-insert-org-entry
-                      (append eventdata (list uid (cdr point-and-level)))))
+                           (append eventdata (list uid (cdr point-and-level)))))
                   (when vtodo
                     (apply 'org-caldav-insert-org-todo
-                      (append tododata (list uid (cdr point-and-level))))))
+                           (append tododata (list uid (cdr point-and-level))))))
                 (push (list org-caldav-calendar-id uid
                             (org-caldav-event-status cur) 'cal->org)
                       org-caldav-sync-result)
@@ -1230,10 +1230,10 @@ which can only be synced to calendar. Ignoring." uid))
           ;; This is a changed event.
           (org-caldav-debug-print
            1 (format "Event UID %s: Changed in Cal --> Org" uid))
-           (cond (vevent (org-caldav-update-org-event))
-             (vtodo (org-caldav-update-org-todo))
-             (t (throw 'strange "Something strange has happend.")))
-           ))
+          (cond (vevent (org-caldav-update-org-event))
+                (vtodo (org-caldav-update-org-todo))
+                (t (throw 'strange "Something strange has happend.")))
+          ))
         ;; Update the event database.
         (org-caldav-event-set-status cur 'synced)
         (with-current-buffer buf
@@ -1253,7 +1253,7 @@ which can only be synced to calendar. Ignoring." uid))
         (setq org-caldav-event-list
               (delete cur org-caldav-event-list))
         (org-caldav-debug-print 1
-         (format "Event UID %s: Deleted from Org" (car cur)))
+                                (format "Event UID %s: Deleted from Org" (car cur)))
         (push (list org-caldav-calendar-id (car cur)
                     'deleted-in-cal 'removed-from-org)
               org-caldav-sync-result)))))
@@ -1316,8 +1316,8 @@ is on s-expression."
     (org-map-entries
      (lambda ()
        (let ((pt (apply 'org-agenda-skip-entry-if org-caldav-skip-conditions))
-              (ts (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
-              (stamp (or (org-entry-get nil "TIMESTAMP" t) (org-entry-get nil "CLOSED" t))))
+             (ts (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
+             (stamp (or (org-entry-get nil "TIMESTAMP" t) (org-entry-get nil "CLOSED" t))))
          (when (or pt (and stamp (> ts (org-time-stamp-to-now stamp))))
            (delete-region (point) (or pt (org-end-of-subtree t)))))))))
 
@@ -1334,32 +1334,32 @@ them.  So we find todo items which have deadline and scheduled
 specified, but one of them has and the other do not have any
 time, and we ask the user to fix that."
   (org-map-entries
-    (lambda ()
-      (let ((sched (org-entry-get nil "SCHEDULED"))
-             (deadl (org-entry-get nil "DEADLINE"))
-             kchoice)
-        (when (and sched deadl)
-          (when (and (org-caldav-timestamp-has-time-p sched)
-                  (not (org-caldav-timestamp-has-time-p deadl)))
-            (org-id-goto (org-id-get-create))
-            (setq kchoice (read-char-choice "Scheduled and Deadline
+   (lambda ()
+     (let ((sched (org-entry-get nil "SCHEDULED"))
+           (deadl (org-entry-get nil "DEADLINE"))
+           kchoice)
+       (when (and sched deadl)
+         (when (and (org-caldav-timestamp-has-time-p sched)
+                    (not (org-caldav-timestamp-has-time-p deadl)))
+           (org-id-goto (org-id-get-create))
+           (setq kchoice (read-char-choice "Scheduled and Deadline
             set.  For syncing you need to (s) set time on
             DEADLINE, or (d) delete SCHEDULED time."
-                        '(?s ?d)))
-            (cond ((= kchoice ?s) (org-deadline nil))
-              ((= kchoice ?d) (org--deadline-or-schedule nil 'scheduled
-                                (replace-regexp-in-string " [0-2][0-9]:[0-5][0-9]" "" sched)))))
-          (when (and (not (org-caldav-timestamp-has-time-p sched))
-                  (org-caldav-timestamp-has-time-p deadl))
-            (org-id-goto (org-entry-get nil "ID"))
-            (setq kchoice (read-char-choice "Scheduled and Deadline
+                                           '(?s ?d)))
+           (cond ((= kchoice ?s) (org-deadline nil))
+                 ((= kchoice ?d) (org--deadline-or-schedule nil 'scheduled
+                                                            (replace-regexp-in-string " [0-2][0-9]:[0-5][0-9]" "" sched)))))
+         (when (and (not (org-caldav-timestamp-has-time-p sched))
+                    (org-caldav-timestamp-has-time-p deadl))
+           (org-id-goto (org-entry-get nil "ID"))
+           (setq kchoice (read-char-choice "Scheduled and Deadline
             set.  For syncing you need to (s) set time on
             SCHEDULED, or (d) delete DEADLINE time."
-                        '(?s ?d)))
-            (cond ((= kchoice ?s) (org-schedule nil))
-              ((= kchoice ?d) (org--deadline-or-schedule nil 'deadline
-                                (replace-regexp-in-string " [0-2][0-9]:[0-5][0-9]" "" sched))))))))
-    nil orgfiles))
+                                           '(?s ?d)))
+           (cond ((= kchoice ?s) (org-schedule nil))
+                 ((= kchoice ?d) (org--deadline-or-schedule nil 'deadline
+                                                            (replace-regexp-in-string " [0-2][0-9]:[0-5][0-9]" "" sched))))))))
+   nil orgfiles))
 
 (defun org-caldav-generate-ics ()
   "Generate ICS file from `org-caldav-files'.
@@ -1382,11 +1382,11 @@ Returns buffer containing the ICS file."
         (icalendar-uid-format "orgsexp-%h")
         (org-export-before-parsing-hook
          (append org-export-before-parsing-hook
-           (when (or org-caldav-skip-conditions
-                   org-caldav-days-in-past) '(org-caldav-skip-function))))
-         (org-export-before-parsing-hook
-           (append org-export-before-parsing-hook
-           (when org-caldav-todo-deadline-schedule-warning-days '(org-caldav-scheduled-from-deadline))))
+                 (when (or org-caldav-skip-conditions
+                           org-caldav-days-in-past) '(org-caldav-skip-function))))
+        (org-export-before-parsing-hook
+         (append org-export-before-parsing-hook
+                 (when org-caldav-todo-deadline-schedule-warning-days '(org-caldav-scheduled-from-deadline))))
         (org-icalendar-date-time-format
          (cond
           ((and org-icalendar-timezone
@@ -1509,7 +1509,7 @@ If LEVEL is nil, it defaults to 1.
 Returns MD5 from entry."
   (insert (make-string (or level 1) ?*) " " summary "\n")
   (insert (if org-adapt-indentation "  " "")
-   (org-caldav-create-time-range start-d start-t end-d end-t) "\n")
+          (org-caldav-create-time-range start-d start-t end-d end-t) "\n")
   (when (> (length description) 0)
     (insert "  " description "\n"))
   (forward-line -1)
@@ -1544,18 +1544,18 @@ If LEVEL is nil, it defaults to 1.
 
 Returns MD5 from entry."
   (let* ((nprio (string-to-number (or priority "0")))
-          (r nil)
-          (vprio (dolist (p org-caldav-todo-priority r)
-                   (when (>= nprio (car p))
-                     (setq r (car (cdr p))))))
-          (prio (if vprio (concat "[#" vprio "] ") ""))
-          (npercent (string-to-number (or percent-complete "0")))
-          (todostate (dolist (to org-caldav-todo-percent-states tstate)
-                       (when (>= npercent (car to))
-                         (setq tstate (car (cdr to)))))))
+         (r nil)
+         (vprio (dolist (p org-caldav-todo-priority r)
+                  (when (>= nprio (car p))
+                    (setq r (car (cdr p))))))
+         (prio (if vprio (concat "[#" vprio "] ") ""))
+         (npercent (string-to-number (or percent-complete "0")))
+         (todostate (dolist (to org-caldav-todo-percent-states tstate)
+                      (when (>= npercent (car to))
+                        (setq tstate (car (cdr to)))))))
     (insert (make-string (or level 1) ?*) " "
-      todostate " " prio
-      summary "\n"))
+            todostate " " prio
+            summary "\n"))
   (when start-d
     (org--deadline-or-schedule nil 'scheduled (org-caldav-convert-to-org-time start-d start-t)))
   (when due-d
@@ -1565,13 +1565,13 @@ Returns MD5 from entry."
   (org-caldav-set-org-tags categories)
   (when (> (length description) 0)
     (insert "  " description "\n"))
-;;  (forward-line -1)
+  ;;  (forward-line -1)
   (when uid
     (org-set-property "ID" (url-unhex-string uid)))
   (org-set-tags-to org-caldav-select-tags)
   (md5 (buffer-substring-no-properties
-         (org-entry-beginning-position)
-         (org-entry-end-position))))
+        (org-entry-beginning-position)
+        (org-entry-end-position))))
 
 (defun org-caldav-update-org-event ()
   "Updates the org entry."
@@ -1585,30 +1585,30 @@ Returns MD5 from entry."
         (org-caldav-backup-item))
       ;; See what we should sync.
       (when (or (eq org-caldav-sync-changes-to-org 'title-only)
-              (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
+                (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
         ;; Sync title
-    (org-caldav-change-heading (nth 4 eventdata))
-    ;; and location
-    (org-caldav-change-location (nth 6 eventdata)))
+        (org-caldav-change-heading (nth 4 eventdata))
+        ;; and location
+        (org-caldav-change-location (nth 6 eventdata)))
       (when (or (eq org-caldav-sync-changes-to-org 'timestamp-only)
-              (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
+                (eq org-caldav-sync-changes-to-org 'title-and-timestamp))
         ;; Sync timestamp
         (setq timesync
-          (org-caldav-change-timestamp
-           (apply 'org-caldav-create-time-range (butlast eventdata 3)))))
+              (org-caldav-change-timestamp
+               (apply 'org-caldav-create-time-range (butlast eventdata 3)))))
       (when (eq org-caldav-sync-changes-to-org 'all)
         ;; Sync everything, so first remove the old one.
         (let ((level (org-current-level)))
           (delete-region (org-entry-beginning-position)
-            (org-entry-end-position))
+                         (org-entry-end-position))
           (apply 'org-caldav-insert-org-entry
-            (append eventdata (list uid level)))))
+                 (append eventdata (list uid level)))))
       (setq buf (current-buffer))
       (push (list org-caldav-calendar-id uid
-              (org-caldav-event-status cur)
-              (if (eq timesync 'orgsexp)
-                'error:changed-orgsexp 'cal->org))
-        org-caldav-sync-result))))
+                  (org-caldav-event-status cur)
+                  (if (eq timesync 'orgsexp)
+                      'error:changed-orgsexp 'cal->org))
+            org-caldav-sync-result))))
 
 (defun org-caldav-update-org-todo ()
   "Updates the todo entry.
@@ -1617,7 +1617,7 @@ github if you need some configuration.
 
 This will update:  heading, priority, todo-state, scheduled, deadline.
 This will not update description (at the moment)."
-    ;; no variables needed because this is only run in a specific context
+  ;; no variables needed because this is only run in a specific context
   (let ((marker (org-id-find (car cur) t)))
     (when (null marker)
       (error "Could not find UID %s." (car cur)))
@@ -1629,62 +1629,62 @@ This will not update description (at the moment)."
       (org-caldav-change-heading (nth 6 tododata))
       ;; priority
       (let* ((nprio (string-to-number (or (nth 4 tododata) "0")))
-              (r nil)
-              (vprio (dolist (p org-caldav-todo-priority r)
-                       (when (>= nprio (car p))
-                         (setq r (car (cdr p)))))))
+             (r nil)
+             (vprio (dolist (p org-caldav-todo-priority r)
+                      (when (>= nprio (car p))
+                        (setq r (car (cdr p)))))))
         (when vprio
           (org-priority (string-to-char vprio))))
       ;; todo-state
       (let* ((npercent (string-to-number (nth 5 tododata)))
-              (todostate (dolist (to org-caldav-todo-percent-states tstate)
-                           (when (>= npercent (car to))
-                             (setq tstate (car (cdr to)))))))
+             (todostate (dolist (to org-caldav-todo-percent-states tstate)
+                          (when (>= npercent (car to))
+                            (setq tstate (car (cdr to)))))))
         (org-todo todostate))
       ;; scheduled, deadline
       (when (nth 0 tododata)
         (org--deadline-or-schedule nil 'scheduled
-          (org-caldav-convert-to-org-time (nth 0 tododata) (nth 1 tododata))))
+                                   (org-caldav-convert-to-org-time (nth 0 tododata) (nth 1 tododata))))
       (when (nth 2 tododata)
         (org--deadline-or-schedule nil 'deadline (org-caldav-convert-to-org-time (nth 2 tododata) (nth 3 tododata))))
       (when (nth 8 tododata)
         (org-add-planning-info 'closed
-          (org-caldav-convert-to-org-time (nth 8 tododata) (nth 9 tododata))))
+                               (org-caldav-convert-to-org-time (nth 8 tododata) (nth 9 tododata))))
       (org-caldav-set-org-tags (nth 10 tododata))
       (setq buf (current-buffer))
       (push (list org-caldav-calendar-id uid
-              (org-caldav-event-status cur)
-              (if (eq timesync 'orgsexp)
-                'error:changed-orgsexp 'cal->org))
-        org-caldav-sync-result))))
+                  (org-caldav-event-status cur)
+                  (if (eq timesync 'orgsexp)
+                      'error:changed-orgsexp 'cal->org))
+            org-caldav-sync-result))))
 
 (defun org-caldav-scheduled-from-deadline (backend)
   "Create a scheduled entry from deadline."
   (when (eq backend 'icalendar)
     (org-map-entries
-      (lambda ()
-        (let* ((sched (org-element-property :scheduled (org-element-at-point)))
-                (ts (org-element-property :deadline (org-element-at-point)))
-                (raw (org-element-property :raw-value ts))
-                (wu (org-element-property :warning-unit ts))
-                (wv (org-element-property :warning-value ts))
-                (dip (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
-                (stamp (org-entry-get nil "DEADLINE")))
-          ;; skip if to old:
-          (unless (and dip stamp (> dip (org-time-stamp-to-now stamp)))
-            (when (and ts (not sched))
-              (org--deadline-or-schedule nil 'scheduled raw)
-              (search-forward "SCHEDULED: ")
-              (forward-char)
-              (if wv
-                (progn
-                  (cond ((eq wu 'week) (setq wu 'day wv (* wv 7)))
-                    ((eq wu 'hour) (setq wu 'minute wv (* wv 60))))
-                  (org-timestamp-change (* wv -1) wu))
-                (org-timestamp-change (* org-deadline-warning-days -1) 'day))))
-          (org-back-to-heading)
-          (org-caldav-debug-print 2 (format "scheduled: %s" (org-entry-get nil
-                                                              "SCHEDULED" t))))))))
+     (lambda ()
+       (let* ((sched (org-element-property :scheduled (org-element-at-point)))
+              (ts (org-element-property :deadline (org-element-at-point)))
+              (raw (org-element-property :raw-value ts))
+              (wu (org-element-property :warning-unit ts))
+              (wv (org-element-property :warning-value ts))
+              (dip (when org-caldav-days-in-past (* (abs org-caldav-days-in-past) -1)))
+              (stamp (org-entry-get nil "DEADLINE")))
+         ;; skip if to old:
+         (unless (and dip stamp (> dip (org-time-stamp-to-now stamp)))
+           (when (and ts (not sched))
+             (org--deadline-or-schedule nil 'scheduled raw)
+             (search-forward "SCHEDULED: ")
+             (forward-char)
+             (if wv
+                 (progn
+                   (cond ((eq wu 'week) (setq wu 'day wv (* wv 7)))
+                         ((eq wu 'hour) (setq wu 'minute wv (* wv 60))))
+                   (org-timestamp-change (* wv -1) wu))
+               (org-timestamp-change (* org-deadline-warning-days -1) 'day))))
+         (org-back-to-heading)
+         (org-caldav-debug-print 2 (format "scheduled: %s" (org-entry-get nil
+                                                                          "SCHEDULED" t))))))))
 
 
 (defun org-caldav-set-org-tags (tags)
@@ -1693,13 +1693,13 @@ This will not update description (at the moment)."
   (save-excursion
     (org-back-to-heading)
     (if (> (length tags) 0)
-      (let (cleantags)
-        (dolist (i (split-string tags ","))
-          (setq cleantags (cons
-                            (replace-regexp-in-string " " "-" (string-trim i))
-                            cleantags)))
-        (org-set-tags-to (reverse cleantags))
-        (org-set-tags t))
+        (let (cleantags)
+          (dolist (i (split-string tags ","))
+            (setq cleantags (cons
+                             (replace-regexp-in-string " " "-" (string-trim i))
+                             cleantags)))
+          (org-set-tags-to (reverse cleantags))
+          (org-set-tags t))
       (org-set-tags-to nil))))
 
 (defun org-caldav-create-time-range (start-d start-t end-d end-t)
@@ -1707,10 +1707,10 @@ This will not update description (at the moment)."
   (with-temp-buffer
     (org-caldav-insert-org-time-stamp start-d start-t)
     (if (and end-d
-          (not (equal end-d start-d)))
-      (progn
-        (insert "--")
-        (org-caldav-insert-org-time-stamp end-d end-t))
+             (not (equal end-d start-d)))
+        (progn
+          (insert "--")
+          (org-caldav-insert-org-time-stamp end-d end-t))
       (when end-t
         ;; Same day, different time.
         (backward-char 1)
@@ -1721,20 +1721,20 @@ This will not update description (at the moment)."
   "Insert org time stamp using DATE and TIME at point.
 DATE is given as european date (DD MM YYYY)."
   (let* ((stime (when time (mapcar 'string-to-number
-                             (split-string time ":"))))
-          (hours (if time (car stime) 0))
-          (minutes (if time (nth 1 stime) 0))
-          (sdate (mapcar 'string-to-number (split-string date)))
-          (day (car sdate))
-          (month (nth 1 sdate))
-          (year (nth 2 sdate))
-          (internaltime (encode-time 0 minutes hours day month year)))
+                                   (split-string time ":"))))
+         (hours (if time (car stime) 0))
+         (minutes (if time (nth 1 stime) 0))
+         (sdate (mapcar 'string-to-number (split-string date)))
+         (day (car sdate))
+         (month (nth 1 sdate))
+         (year (nth 2 sdate))
+         (internaltime (encode-time 0 minutes hours day month year)))
     (insert
-      (concat "<"
-        (if time
-          (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
-          (format-time-string "%Y-%m-%d %a" internaltime))
-        ">"))))
+     (concat "<"
+             (if time
+                 (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
+               (format-time-string "%Y-%m-%d %a" internaltime))
+             ">"))))
 
 
 ;; is it needed?
@@ -1743,33 +1743,33 @@ DATE is given as european date (DD MM YYYY)."
   "Insert org time stamp using DATE and TIME at point.
 DATE is given as european date (DD MM YYYY)."
   (let* ((stime (when time (mapcar 'string-to-number
-                             (split-string time ":"))))
-          (hours (if time (car stime) 0))
-          (minutes (if time (nth 1 stime) 0))
-          (sdate (mapcar 'string-to-number (split-string date)))
-          (day (car sdate))
-          (month (nth 1 sdate))
-          (year (nth 2 sdate))
-          (internaltime (encode-time 0 minutes hours day month year)))
+                                   (split-string time ":"))))
+         (hours (if time (car stime) 0))
+         (minutes (if time (nth 1 stime) 0))
+         (sdate (mapcar 'string-to-number (split-string date)))
+         (day (car sdate))
+         (month (nth 1 sdate))
+         (year (nth 2 sdate))
+         (internaltime (encode-time 0 minutes hours day month year)))
     (concat
-      (if time
-        (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
-        (format-time-string "%Y-%m-%d %a" internaltime))
-      )))
+     (if time
+         (format-time-string "%Y-%m-%d %a %H:%M" internaltime)
+       (format-time-string "%Y-%m-%d %a" internaltime))
+     )))
 
 (defun org-caldav-save-sync-state ()
   "Save org-caldav sync database to disk.
 See also `org-caldav-save-directory'."
   (with-temp-buffer
     (insert ";; This is the sync state from org-caldav\n;; calendar-id: "
-      org-caldav-calendar-id "\n;; Do not modify this file.\n\n")
+            org-caldav-calendar-id "\n;; Do not modify this file.\n\n")
     (insert "(setq org-caldav-event-list\n'")
     (let ((print-length nil)
-           (print-level nil))
+          (print-level nil))
       (prin1 (delq nil
-               (mapcar (lambda (ev) (unless (eq (org-caldav-event-status ev) 'error) ev))
-                 org-caldav-event-list))
-        (current-buffer)))
+                   (mapcar (lambda (ev) (unless (eq (org-caldav-event-status ev) 'error) ev))
+                           org-caldav-event-list))
+             (current-buffer)))
     (insert ")\n")
     ;; This is just cosmetics.
     (goto-char (point-min))
@@ -1777,10 +1777,10 @@ See also `org-caldav-save-directory'."
       (insert "\n"))
     ;; Save the current value of org-caldav-files
     (insert "(setq org-caldav-previous-files '"
-      (prin1-to-string org-caldav-files) ")\n")
+            (prin1-to-string org-caldav-files) ")\n")
     ;; Save it.
     (write-region (point-min) (point-max)
-      (org-caldav-sync-state-filename org-caldav-calendar-id))))
+                  (org-caldav-sync-state-filename org-caldav-calendar-id))))
 
 (defun org-caldav-load-sync-state ()
   "Load org-caldav sync database from disk."
@@ -1793,8 +1793,8 @@ See also `org-caldav-save-directory'."
 (defun org-caldav-sync-state-filename (id)
   "Return filename for saving the sync state of calendar with ID."
   (expand-file-name
-    (concat "org-caldav-" (substring (md5 id) 1 8) ".el")
-    org-caldav-save-directory))
+   (concat "org-caldav-" (substring (md5 id) 1 8) ".el")
+   org-caldav-save-directory))
 
 (defvar org-caldav-sync-results-mode-map
   (let ((map (make-sparse-keymap)))
@@ -1810,15 +1810,15 @@ See also `org-caldav-save-directory'."
     (erase-buffer)
     (insert "CalDAV Sync finished.\n\n")
     (if (null org-caldav-sync-result)
-      (insert "Nothing was done.")
+        (insert "Nothing was done.")
       (insert "== Sync errors: \n\n")
       (org-caldav-sync-result-print-entries
-        (org-caldav-sync-result-filter-errors))
+       (org-caldav-sync-result-filter-errors))
       (insert "\n== Successful syncs: \n\n")
       (org-caldav-sync-result-print-entries
-        (org-caldav-sync-result-filter-errors t)))
+       (org-caldav-sync-result-filter-errors t)))
     (if (fboundp 'pop-to-buffer-same-window)
-      (pop-to-buffer-same-window (current-buffer))
+        (pop-to-buffer-same-window (current-buffer))
       (pop-to-buffer (current-buffer)))
     (setq buffer-read-only t)
     (goto-char (point-min))
@@ -1829,35 +1829,35 @@ See also `org-caldav-save-directory'."
   "Return items from sync results with errors.
 If COMPLEMENT is non-nil, return all item without errors."
   (delq nil
-    (mapcar
-      (lambda (x)
-        (if (string-match "^error" (symbol-name (car (last x))))
-          (unless complement x)
-          (when complement x)))
-      org-caldav-sync-result)))
+        (mapcar
+         (lambda (x)
+           (if (string-match "^error" (symbol-name (car (last x))))
+               (unless complement x)
+             (when complement x)))
+         org-caldav-sync-result)))
 
 (defun org-caldav-sync-result-print-entries (entries)
   "Helper function to print ENTRIES."
   (if (null entries)
-    (insert "None.\n")
+      (insert "None.\n")
     (dolist (entry entries)
       (let ((deleted (or (eq (nth 2 entry) 'deleted-in-org)
-                       (eq (nth 2 entry) 'deleted-in-cal))))
+                         (eq (nth 2 entry) 'deleted-in-cal))))
         (insert "UID: ")
         (let ((start (point)))
           (insert (nth 1 entry))
           (unless deleted
             (put-text-property start (point)
-              'face 'link)))
+                               'face 'link)))
         (when (and (eq org-caldav-show-sync-results 'with-headings)
-                (not deleted))
+                   (not deleted))
           (insert "\n   Title: "
-            (or (org-caldav-get-heading-from-uid (nth 1 entry))
-              "(no title)")))
+                  (or (org-caldav-get-heading-from-uid (nth 1 entry))
+                      "(no title)")))
         (insert "\n   Status: "
-          (symbol-name (nth 2 entry))
-          "  Action: "
-          (symbol-name (nth 3 entry)))
+                (symbol-name (nth 2 entry))
+                "  Action: "
+                (symbol-name (nth 3 entry)))
         (when org-caldav-calendars
           (insert "\n   Calendar: " (car entry)))
         (insert "\n\n")))))
@@ -1866,23 +1866,23 @@ If COMPLEMENT is non-nil, return all item without errors."
   "Get org heading from entry with UID."
   (let ((marker (org-id-find uid t)))
     (if (null marker)
-      "(Could not find UID)"
+        "(Could not find UID)"
       (with-current-buffer (marker-buffer marker)
         (goto-char (marker-position marker))
         (org-narrow-to-subtree)
         (goto-char (point-min))
         (org-show-subtree)
         (prog1
-          (if (re-search-forward org-complex-heading-regexp nil t)
-            (match-string 4)
-            "(Could not find heading)")
+            (if (re-search-forward org-complex-heading-regexp nil t)
+                (match-string 4)
+              "(Could not find heading)")
           (widen))))))
 
 (defun org-caldav-goto-uid ()
   "Jump to UID unter point."
   (interactive)
   (when (equal (plist-get (text-properties-at (point)) 'face)
-          'link)
+               'link)
     (beginning-of-line)
     (looking-at "UID: \\(.+\\)$")
     (org-id-goto (match-string 1))))
@@ -1890,7 +1890,7 @@ If COMPLEMENT is non-nil, return all item without errors."
 (defun org-caldav-get-calendar-summary-from-uid (uid)
   "Get summary from UID from calendar."
   (let ((buf (org-caldav-get-event uid))
-         (heading ""))
+        (heading ""))
     (when buf
       (with-current-buffer buf
         (goto-char (point-min))
@@ -1911,90 +1911,90 @@ which can be fed into `org-caldav-insert-org-entry'."
     (insert decoded))
   (goto-char (point-min))
   (let* ((calendar-date-style 'european)
-          (ical-list (icalendar--read-element nil nil))
-          (e (car (icalendar--all-events ical-list)))
-          (zone-map (icalendar--convert-all-timezones ical-list))
-          (dtstart (icalendar--get-event-property e 'DTSTART))
-          (dtstart-zone (icalendar--find-time-zone
-                          (icalendar--get-event-property-attributes
-                            e 'DTSTART)
-                          zone-map))
-          (dtstart-dec (icalendar--decode-isodatetime dtstart nil
-                         dtstart-zone))
-          (start-d (icalendar--datetime-to-diary-date
-                     dtstart-dec))
-          (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
-          (dtend (icalendar--get-event-property e 'DTEND))
-          (dtend-zone (icalendar--find-time-zone
+         (ical-list (icalendar--read-element nil nil))
+         (e (car (icalendar--all-events ical-list)))
+         (zone-map (icalendar--convert-all-timezones ical-list))
+         (dtstart (icalendar--get-event-property e 'DTSTART))
+         (dtstart-zone (icalendar--find-time-zone
                         (icalendar--get-event-property-attributes
-                          e 'DTEND)
+                         e 'DTSTART)
                         zone-map))
-          (dtend-dec (icalendar--decode-isodatetime dtend
-                       nil dtend-zone))
-          (dtend-1-dec (icalendar--decode-isodatetime dtend -1
-                         dtend-zone))
-          end-d
-          end-1-d
-          end-t
-          (summary (icalendar--convert-string-for-import
-                     (or (icalendar--get-event-property e 'SUMMARY)
+         (dtstart-dec (icalendar--decode-isodatetime dtstart nil
+                                                     dtstart-zone))
+         (start-d (icalendar--datetime-to-diary-date
+                   dtstart-dec))
+         (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
+         (dtend (icalendar--get-event-property e 'DTEND))
+         (dtend-zone (icalendar--find-time-zone
+                      (icalendar--get-event-property-attributes
+                       e 'DTEND)
+                      zone-map))
+         (dtend-dec (icalendar--decode-isodatetime dtend
+                                                   nil dtend-zone))
+         (dtend-1-dec (icalendar--decode-isodatetime dtend -1
+                                                     dtend-zone))
+         end-d
+         end-1-d
+         end-t
+         (summary (icalendar--convert-string-for-import
+                   (or (icalendar--get-event-property e 'SUMMARY)
                        "No Title")))
-          (description (icalendar--convert-string-for-import
-                         (or (icalendar--get-event-property e 'DESCRIPTION)
+         (description (icalendar--convert-string-for-import
+                       (or (icalendar--get-event-property e 'DESCRIPTION)
                            "")))
-   (location (icalendar--convert-string-for-import
+         (location (icalendar--convert-string-for-import
                     (or (icalendar--get-event-property e 'LOCATION)
                         "")))
-          (rrule (icalendar--get-event-property e 'RRULE))
-          (rdate (icalendar--get-event-property e 'RDATE))
-          (duration (icalendar--get-event-property e 'DURATION)))
+         (rrule (icalendar--get-event-property e 'RRULE))
+         (rdate (icalendar--get-event-property e 'RDATE))
+         (duration (icalendar--get-event-property e 'DURATION)))
     ;; check whether start-time is missing
     (if (and dtstart
-          (string=
-            (cadr (icalendar--get-event-property-attributes
-                    e 'DTSTART))
-            "DATE"))
-      (setq start-t nil))
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'DTSTART))
+              "DATE"))
+        (setq start-t nil))
     (when duration
       (let ((dtend-dec-d (icalendar--add-decoded-times
-                           dtstart-dec
-                           (icalendar--decode-isoduration duration)))
-             (dtend-1-dec-d (icalendar--add-decoded-times
-                              dtstart-dec
-                              (icalendar--decode-isoduration duration
-                                t))))
+                          dtstart-dec
+                          (icalendar--decode-isoduration duration)))
+            (dtend-1-dec-d (icalendar--add-decoded-times
+                            dtstart-dec
+                            (icalendar--decode-isoduration duration
+                                                           t))))
         (if (and dtend-dec (not (eq dtend-dec dtend-dec-d)))
-          (message "Inconsistent endtime and duration for %s"
-            summary))
+            (message "Inconsistent endtime and duration for %s"
+                     summary))
         (setq dtend-dec dtend-dec-d)
         (setq dtend-1-dec dtend-1-dec-d)))
     (setq end-d (if dtend-dec
-                  (icalendar--datetime-to-diary-date dtend-dec)
+                    (icalendar--datetime-to-diary-date dtend-dec)
                   start-d))
     (setq end-1-d (if dtend-1-dec
-                    (icalendar--datetime-to-diary-date dtend-1-dec)
+                      (icalendar--datetime-to-diary-date dtend-1-dec)
                     start-d))
     (setq end-t (if (and
-                      dtend-dec
-                      (not (string=
-                             (cadr
-                               (icalendar--get-event-property-attributes
-                                 e 'DTEND))
-                             "DATE")))
-                  (icalendar--datetime-to-colontime dtend-dec)
+                     dtend-dec
+                     (not (string=
+                           (cadr
+                            (icalendar--get-event-property-attributes
+                             e 'DTEND))
+                           "DATE")))
+                    (icalendar--datetime-to-colontime dtend-dec)
                   start-t))
     ;; Return result
     (list start-d start-t
-      (if end-t end-d end-1-d)
-    end-t summary description location)))
+          (if end-t end-d end-1-d)
+          end-t summary description location)))
 
 (defun org-caldav--icalendar--all-todos (icalendar)
   "Return the list of all existing todos in the given ICALENDAR."
   (let ((result '()))
     (mapc (lambda (elt)
             (setq result (append (icalendar--get-children elt 'VTODO)
-                           result)))
-      (nreverse icalendar))
+                                 result)))
+          (nreverse icalendar))
     result))
 
 
@@ -2011,85 +2011,85 @@ which can be fed into `org-caldav-insert-org-todo'."
     (insert decoded))
   (goto-char (point-min))
   (let* ((calendar-date-style 'european)
-          (ical-list (icalendar--read-element nil nil))
-          (e (car (org-caldav--icalendar--all-todos ical-list)))
-          (zone-map (icalendar--convert-all-timezones ical-list))
-          (dtstart (icalendar--get-event-property e 'DTSTART))
-          (dtstart-zone (icalendar--find-time-zone
-                          (icalendar--get-event-property-attributes
-                            e 'DTSTART)
-                          zone-map))
-          (dtstart-dec (icalendar--decode-isodatetime dtstart nil
-                         dtstart-zone))
-          (start-d (icalendar--datetime-to-diary-date
-                     dtstart-dec))
-          (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
-          (dtdue (icalendar--get-event-property e 'DUE))
-          (dtdue-zone (icalendar--find-time-zone
+         (ical-list (icalendar--read-element nil nil))
+         (e (car (org-caldav--icalendar--all-todos ical-list)))
+         (zone-map (icalendar--convert-all-timezones ical-list))
+         (dtstart (icalendar--get-event-property e 'DTSTART))
+         (dtstart-zone (icalendar--find-time-zone
                         (icalendar--get-event-property-attributes
-                          e 'DUE)
+                         e 'DTSTART)
                         zone-map))
-          (dtdue-dec (icalendar--decode-isodatetime dtdue
-                       nil dtdue-zone))
-          (due-d (icalendar--datetime-to-diary-date
-                   dtdue-dec))
-          (due-t (if dtdue-dec (icalendar--datetime-to-colontime dtdue-dec) nil))
-          (dtcompleted (icalendar--get-event-property e 'COMPLETED))
-          (dtcompleted-zone (icalendar--find-time-zone
-                              (icalendar--get-event-property-attributes
-                                e 'COMPLETED)
-                              zone-map))
-          (dtcompleted-dec (icalendar--decode-isodatetime dtcompleted
-                             nil dtcompleted-zone))
-          (completed-d (icalendar--datetime-to-diary-date
-                         dtcompleted-dec))
-          (completed-t (if dtcompleted-dec (icalendar--datetime-to-colontime dtcompleted-dec) nil))
-          (summary (icalendar--convert-string-for-import
-                     (or (icalendar--get-event-property e 'SUMMARY)
+         (dtstart-dec (icalendar--decode-isodatetime dtstart nil
+                                                     dtstart-zone))
+         (start-d (icalendar--datetime-to-diary-date
+                   dtstart-dec))
+         (start-t (if dtstart-dec (icalendar--datetime-to-colontime dtstart-dec) nil))
+         (dtdue (icalendar--get-event-property e 'DUE))
+         (dtdue-zone (icalendar--find-time-zone
+                      (icalendar--get-event-property-attributes
+                       e 'DUE)
+                      zone-map))
+         (dtdue-dec (icalendar--decode-isodatetime dtdue
+                                                   nil dtdue-zone))
+         (due-d (icalendar--datetime-to-diary-date
+                 dtdue-dec))
+         (due-t (if dtdue-dec (icalendar--datetime-to-colontime dtdue-dec) nil))
+         (dtcompleted (icalendar--get-event-property e 'COMPLETED))
+         (dtcompleted-zone (icalendar--find-time-zone
+                            (icalendar--get-event-property-attributes
+                             e 'COMPLETED)
+                            zone-map))
+         (dtcompleted-dec (icalendar--decode-isodatetime dtcompleted
+                                                         nil dtcompleted-zone))
+         (completed-d (icalendar--datetime-to-diary-date
+                       dtcompleted-dec))
+         (completed-t (if dtcompleted-dec (icalendar--datetime-to-colontime dtcompleted-dec) nil))
+         (summary (icalendar--convert-string-for-import
+                   (or (icalendar--get-event-property e 'SUMMARY)
                        "No Title")))
-          (description (icalendar--convert-string-for-import
-                         (or (icalendar--get-event-property e 'DESCRIPTION)
+         (description (icalendar--convert-string-for-import
+                       (or (icalendar--get-event-property e 'DESCRIPTION)
                            "")))
-          (categories (icalendar--convert-string-for-import
-                        (or (icalendar--get-event-property e 'CATEGORIES)
+         (categories (icalendar--convert-string-for-import
+                      (or (icalendar--get-event-property e 'CATEGORIES)
                           "")))
-          (priority (icalendar--get-event-property e 'PRIORITY))
-          (percent-complete (icalendar--get-event-property e 'PERCENT-COMPLETE))
-          (stat (icalendar--get-event-property e 'STATUS)))
+         (priority (icalendar--get-event-property e 'PRIORITY))
+         (percent-complete (icalendar--get-event-property e 'PERCENT-COMPLETE))
+         (stat (icalendar--get-event-property e 'STATUS)))
     ;; check wether start-time is missing
     (if (and dtstart
-          (string=
-            (cadr (icalendar--get-event-property-attributes
-                    e 'DTSTART))
-            "DATE"))
-      (setq start-t nil))
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'DTSTART))
+              "DATE"))
+        (setq start-t nil))
     ;; same for due-time
     (if (and dtdue
-          (string=
-            (cadr (icalendar--get-event-property-attributes
-                    e 'DUE))
-            "DATE"))
-      (setq due-t nil))
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'DUE))
+              "DATE"))
+        (setq due-t nil))
     ;; and completed
     (if (and dtcompleted
-          (string=
-            (cadr (icalendar--get-event-property-attributes
-                    e 'COMPLETED))
-            "DATE"))
-      (setq completed-t nil))
+             (string=
+              (cadr (icalendar--get-event-property-attributes
+                     e 'COMPLETED))
+              "DATE"))
+        (setq completed-t nil))
     (unless percent-complete
       (setq percent-complete
-        (cond
-          ((string= stat "NEEDS-ACTION") "0")
-          ((string= stat "IN-PROCESS") "50")
-          ((string= stat "COMPLETED") "100")
-          (t "0"))))
+            (cond
+             ((string= stat "NEEDS-ACTION") "0")
+             ((string= stat "IN-PROCESS") "50")
+             ((string= stat "COMPLETED") "100")
+             (t "0"))))
     (list start-d start-t
-      due-d due-t
-      priority percent-complete
-      summary description
-      completed-d completed-t
-      categories)))
+          due-d due-t
+          priority percent-complete
+          summary description
+          completed-d completed-t
+          categories)))
 
 
 ;; This is adapted from url-dav.el, written by Bill Perry.
@@ -2113,14 +2113,14 @@ This switches to OAuth2 if necessary."
           (setq errormessage (buffer-substring (point-min) (point-at-eol)))
           (setq counter (1+ counter))
           (org-caldav-debug-print 1
-            (format "(Try %d) Error when trying to put URL %s: %s"
-              counter url errormessage))
+                                  (format "(Try %d) Error when trying to put URL %s: %s"
+                                          counter url errormessage))
           (kill-buffer))))
     (if buffer
         (kill-buffer buffer)
       (org-caldav-debug-print 1
-        (format "Failed to put URL %s after %d tries with error %s"
-          url org-caldav-retry-attempts errormessage)))
+                              (format "Failed to put URL %s after %d tries with error %s"
+                                      url org-caldav-retry-attempts errormessage)))
     (< counter org-caldav-retry-attempts)))
 
 ;;;###autoload

--- a/org-caldav.el
+++ b/org-caldav.el
@@ -804,7 +804,9 @@ If RESUME is non-nil, try to resume."
       (dolist (filename (append org-caldav-files
                                 (list (org-caldav-inbox-file org-caldav-inbox))))
         (when (not (file-exists-p filename))
-          (user-error "File %s does not exist" filename)))
+          (if (yes-or-no-p (format "File %s does not exist, create it?" filename))
+              (write-region "" nil filename)
+            (user-error "File %s does not exist" filename))))
       ;; Check if we need to do OAuth2
       (when (org-caldav-use-oauth2)
         ;; We need to do oauth2. Check if it is available.


### PR DESCRIPTION
In some cases the events or todos returned from caldav server (nextcloud 23 in
my case) have no SEQUENCE number in them. Original code would mangle the
icalendar entry in those cases, deleting the first line (usually
BEGIN:VEVENT/BEGIN:VTODO).

With this change we delete the line with SEQUENCE only if we actually find it
and otherwise insert a fresh one just after line starting with "BEGIN"